### PR TITLE
Fix imports

### DIFF
--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -33,8 +33,8 @@ from .Options import SohOptions
 from .RegionAgeAccess import reset_age_access, update_age_access
 from .Regions import region_data_table
 from .Enums import *
-from worlds.oot_soh.location_access import root
-from worlds.oot_soh.location_access.overworld import \
+from ...location_access import root
+from ...location_access.overworld import \
     castle_grounds, \
     death_mountain_crater, \
     death_mountain_trail, \
@@ -49,7 +49,7 @@ from worlds.oot_soh.location_access.overworld import \
     kokiri_forest, \
     lake_hylia, \
     lon_lon_ranch
-from worlds.oot_soh.location_access.dungeons import \
+from ...location_access.dungeons import \
     bottom_of_the_well, \
     deku_tree, \
     dodongos_cavern, \

--- a/worlds/oot_soh/location_access/dungeons/bottom_of_the_well.py
+++ b/worlds/oot_soh/location_access/dungeons/bottom_of_the_well.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/deku_tree.py
+++ b/worlds/oot_soh/location_access/dungeons/deku_tree.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import *
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import *
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/dodongos_cavern.py
+++ b/worlds/oot_soh/location_access/dungeons/dodongos_cavern.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import Regions, Items, Locations, Enemies, Combat_Ranges
-from worlds.oot_soh.LogicHelpers import (can_break_mud_walls, is_adult, has_explosives, can_attack, take_damage, can_shield, can_kill_enemy,
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import Regions, Items, Locations, Enemies, Combat_Ranges
+from ...LogicHelpers import (can_break_mud_walls, is_adult, has_explosives, can_attack, take_damage, can_shield, can_kill_enemy,
                                   has_fire_source_with_torch, can_use, can_do_trick, can_jump_slash, blast_or_smash)
 
 if TYPE_CHECKING:

--- a/worlds/oot_soh/location_access/dungeons/fire_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/fire_temple.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/forest_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/forest_temple.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/ganons_castle.py
+++ b/worlds/oot_soh/location_access/dungeons/ganons_castle.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/gerudo_training_ground.py
+++ b/worlds/oot_soh/location_access/dungeons/gerudo_training_ground.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/ice_cavern.py
+++ b/worlds/oot_soh/location_access/dungeons/ice_cavern.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
+++ b/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/shadow_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/shadow_temple.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/spirit_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/spirit_temple.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/dungeons/water_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/water_temple.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/castle_grounds.py
+++ b/worlds/oot_soh/location_access/overworld/castle_grounds.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/death_mountain_crater.py
+++ b/worlds/oot_soh/location_access/overworld/death_mountain_crater.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
+++ b/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/desert_colossus.py
+++ b/worlds/oot_soh/location_access/overworld/desert_colossus.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/gerudo_fortress.py
+++ b/worlds/oot_soh/location_access/overworld/gerudo_fortress.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/gerudo_valley.py
+++ b/worlds/oot_soh/location_access/overworld/gerudo_valley.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/goron_city.py
+++ b/worlds/oot_soh/location_access/overworld/goron_city.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/graveyard.py
+++ b/worlds/oot_soh/location_access/overworld/graveyard.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/haunted_wasteland.py
+++ b/worlds/oot_soh/location_access/overworld/haunted_wasteland.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/hyrule_field.py
+++ b/worlds/oot_soh/location_access/overworld/hyrule_field.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/kakariko.py
+++ b/worlds/oot_soh/location_access/overworld/kakariko.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/kokiri_forest.py
+++ b/worlds/oot_soh/location_access/overworld/kokiri_forest.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING, Dict
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/lake_hylia.py
+++ b/worlds/oot_soh/location_access/overworld/lake_hylia.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/lon_lon_ranch.py
+++ b/worlds/oot_soh/location_access/overworld/lon_lon_ranch.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/lost_woods.py
+++ b/worlds/oot_soh/location_access/overworld/lost_woods.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/market.py
+++ b/worlds/oot_soh/location_access/overworld/market.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/sacred_forest_meadow.py
+++ b/worlds/oot_soh/location_access/overworld/sacred_forest_meadow.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/temple_of_time.py
+++ b/worlds/oot_soh/location_access/overworld/temple_of_time.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/thieves_hideout.py
+++ b/worlds/oot_soh/location_access/overworld/thieves_hideout.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/zoras_domain.py
+++ b/worlds/oot_soh/location_access/overworld/zoras_domain.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/zoras_fountain.py
+++ b/worlds/oot_soh/location_access/overworld/zoras_fountain.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/overworld/zoras_river.py
+++ b/worlds/oot_soh/location_access/overworld/zoras_river.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Regions import double_link_regions
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions)
+from ...Regions import double_link_regions
+from ...Items import SohItem
+from ...Locations import SohLocation, SohLocationData
+from ...Enums import *
+from ...LogicHelpers import add_locations, connect_regions
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld

--- a/worlds/oot_soh/location_access/root.py
+++ b/worlds/oot_soh/location_access/root.py
@@ -1,10 +1,10 @@
 from typing import TYPE_CHECKING
 
 from worlds.generic.Rules import set_rule
-from worlds.oot_soh.Items import SohItem
-from worlds.oot_soh.Locations import SohLocation, SohLocationData
-from worlds.oot_soh.Enums import *
-from worlds.oot_soh.LogicHelpers import (add_locations, connect_regions, can_use)
+from ..Items import SohItem
+from ..Locations import SohLocation, SohLocationData
+from ..Enums import *
+from ..LogicHelpers import (add_locations, connect_regions, can_use)
 
 if TYPE_CHECKING:
     from worlds.oot_soh import SohWorld


### PR DESCRIPTION
Absolute imports only work if the world is in the Archipelago/worlds folder.
Since it's usually in the custom_worlds folder for players, you need to use relative imports.