### PR TITLE
Added Both ages support for can_reach ages

### DIFF
--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -3467,6 +3467,7 @@ class Events(str, Enum):
 class Ages(str, Enum):
     CHILD = "child"
     ADULT = "adult"
+    BOTH = "both"
     null = None
 
 

--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -344,7 +344,10 @@ def is_child(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
 
 
 def can_be_both_ages(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
-    return is_child(bundle) and is_adult(bundle)
+    state = bundle[0]
+    parent_region = bundle[1]
+    world = bundle[2]
+    return state._soh_can_reach_as_age(parent_region, Ages.BOTH, world.player)
 
 
 def starting_age(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:

--- a/worlds/oot_soh/RegionAgeAccess.py
+++ b/worlds/oot_soh/RegionAgeAccess.py
@@ -69,12 +69,17 @@ class SohAgeLogic(LogicMixin):
                     queue.extend(new_region.exits)
                     self.path[new_region] = (new_region.name, self.path.get(connection, None))
     
-    def _soh_can_reach_as_age(self, region: Regions, age: Ages, player: int): # Todo, type safety to age enum
+    def _soh_can_reach_as_age(self, region: Regions, age: Ages, player: int):
         if self._soh_age[player] is Ages.null:
             # first layer of recursion
             self._soh_age[player] = age
             can_reach = self.multiworld.get_region(region.value, player).can_reach(self)
             self._soh_age[player] = Ages.null
             return can_reach
+        if age is Ages.BOTH:
+            stored_age = self._soh_age[player]
+            self._soh_age[player] = age
+            can_reach = self.multiworld.get_region(region.value, player).can_reach(self)
+            self._soh_age[player] = stored_age
         return self._soh_age[player] == age
 

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -83,10 +83,12 @@ class SohRegion(Region):
             state._soh_update_age_reachable_regions(self.player)
             state._soh_age[self.player] = stored_age
         
-        if state._soh_age[self.player] == "child":
+        if state._soh_age[self.player] == Ages.CHILD:
             return self in state._soh_child_reachable_regions[self.player]
-        elif state._soh_age[self.player] == "adult":
+        elif state._soh_age[self.player] == Ages.ADULT:
             return self in state._soh_adult_reachable_regions[self.player]
+        elif state._soh_age[self.player] == Ages.BOTH:
+            return self in state._soh_child_reachable_regions[self.player] and self in state._soh_adult_reachable_regions[self.player]
         else:
             return self in state._soh_child_reachable_regions[self.player] or self in state._soh_adult_reachable_regions[self.player]
 


### PR DESCRIPTION
The previous implementation won't work because you can't simply and is_child and is_adult because state is searching the graph for either of those two stages and will exclude the other.

Added the both option to the enum which will temporarily overwrite age in state so a call can be made to our own can_reach function. this ensures the cache still gets checked for staleness.