### PR TITLE
Forest Temple: Fix naming for courtyard raised island

### DIFF
--- a/worlds/oot_soh/location_access/dungeons/forest_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/forest_temple.py
@@ -408,11 +408,11 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.FOREST_TEMPLE_FALLING_ROOM, world, [
         (Regions.FOREST_TEMPLE_NE_OUTDOORS_LOWER, lambda bundle: True),
         (Regions.FOREST_TEMPLE_GREEN_POE_ROOM, lambda bundle: True),
-        (Regions.FOREST_TEMPLE_COURTYARD_RAISED_ISLAND, lambda bundle: True),
-        (Regions.FOREST_TEMPLE_COURTYARD_RAISED_ISLAND_GS, lambda bundle: (can_use(Items.FAIRY_BOW, bundle) or
-                                                                             can_use(Items.FAIRY_SLINGSHOT, bundle) or
-                                                                             can_use(Items.DINS_FIRE, bundle) or
-                                                                             has_explosives(bundle)))
+        (Regions.FOREST_TEMPLE_NE_COURTYARD_SKULLTULA_ISLAND, lambda bundle: True),
+        (Regions.FOREST_TEMPLE_NE_COURTYARD_SKULLTULA_ISLAND_GS, lambda bundle: (can_use(Items.FAIRY_BOW, bundle) or
+                                                                                 can_use(Items.FAIRY_SLINGSHOT, bundle) or
+                                                                                 can_use(Items.DINS_FIRE, bundle) or
+                                                                                 has_explosives(bundle)))
     ])
     
     ## Forest Temple Green Poe Room


### PR DESCRIPTION
The names it was using before weren't in the regions enum, nor did they match how the regions were named elsewhere in the file. They now match how they were named elsewhere in the file.

These regions were made to deal with `RC_FOREST_TEMPLE_RAISED_ISLAND_COURTYARD_CHEST` and `RC_FOREST_TEMPLE_GS_RAISED_ISLAND_COURTYARD`, which you can reference here: https://github.com/HarbourMasters/Shipwright/blob/develop/soh/soh/Enhancements/randomizer/location_access/dungeons/forest_temple.cpp