### PR TITLE
Logic Helpers: Fix has_explosive using bomb_bag instead of progressive_bomb_bag

### DIFF
--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -264,7 +264,7 @@ def can_play_song(song: Enum, bundle: tuple[CollectionState, Regions, "SohWorld"
 
 def has_explosives(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     """Check if Link has access to explosives (bombs or bombchus)."""
-    return can_use_any([Items.BOMB_BAG, Items.PROGRESSIVE_BOMBCHU], bundle)
+    return can_use_any([Items.PROGRESSIVE_BOMB_BAG, Items.PROGRESSIVE_BOMBCHU], bundle)
 
 
 def blast_or_smash(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:


### PR DESCRIPTION
Bomb_bag doesn't exist in Items.py, but Progressive_bomb_bag does.
At some point, a more clean fix should be done, since right now you can use bomb_bag for has_item, but not for can_use.
A collect/remove override would make it so you can use either name and it'd be fine.