### PR TITLE
Fix typo in Locations.py imports

### DIFF
--- a/worlds/oot_soh/Locations.py
+++ b/worlds/oot_soh/Locations.py
@@ -1,4 +1,4 @@
-from Enums import Locations
+from .Enums import Locations
 
 from typing import Dict, TYPE_CHECKING
 


### PR DESCRIPTION
It's missing the ., so it's not finding the file