### PR TITLE
Swap to using StrEnum

### DIFF
--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from enum import StrEnum, IntEnum
 from functools import total_ordering #allows defining orders with fewer functions; with this decorator only __eq__ and __lt__ is needed, and since enums implement __eq__ we can just implement __lt__
 
-class Regions(str, Enum):
+class Regions(StrEnum):
     """List of all region enums"""
 
     ROOT = "Menu"
@@ -698,7 +698,7 @@ class Regions(str, Enum):
 #TODO go through this and Locations for any that aren't needed or should be events
 #For any such entries, remove them from Items and Locations and add to Events. Also, set up event registration.
 #Later, we'll go through the events and replace some with other methods
-class Items(str, Enum):
+class Items(StrEnum):
     KOKIRI_SWORD = "Kokiri Sword"
     MASTER_SWORD = "Master Sword"
     GIANTS_KNIFE = "Giant's Knife"
@@ -979,7 +979,7 @@ class Items(str, Enum):
     EPONA = "Epona"
     MAX = "Max"
 
-class Locations(str, Enum):
+class Locations(StrEnum):
     LINKS_POCKET = "Link's Pocket"
     QUEEN_GOHMA = "Queen Gohma"
     KING_DODONGO = "King Dodongo"
@@ -3439,7 +3439,7 @@ class Locations(str, Enum):
     HF_INSIDE_FENCE_GROTTO_BEEHIVE = "HF Inside Fence Grotto Beehive"
     HF_FENCE_GROTTO_STORMS_FAIRY = "HF Fence Grotto Storms Fairy"
 
-class Enemies(str, Enum):
+class Enemies(StrEnum):
     GOLD_SKULLTULA = "gold_skulltula"
     BIG_SKULLTULA = "big_skulltula"
     DODONGO = "dodongo"
@@ -3495,7 +3495,7 @@ class Enemies(str, Enum):
     OCTOROK = "octorok"
     
 @total_ordering
-class EnemyDistance(Enum):
+class EnemyDistance(IntEnum):
     CLOSE = 1
     SHORT_JUMPSLASH = 2
     MASTER_SWORD_JUMPSLASH = 3
@@ -3509,7 +3509,7 @@ class EnemyDistance(Enum):
     def __lt__(self, other):
         return self.value < other.value
 
-class Events(str, Enum):
+class Events(StrEnum):
     CAN_FARM_STICKS = "Can Farm Sticks"
     CAN_FARM_NUTS = "Can Farm Nuts"
     CAN_BUY_BEANS = "Can Buy Beans"
@@ -3550,14 +3550,14 @@ class Events(str, Enum):
     KAKARIKO_GATE_OPEN = "Kakariko Gate Open"
     GAME_COMPLETED = "Game Completed"
 
-class Ages(str, Enum):
+class Ages(StrEnum):
     CHILD = "child"
     ADULT = "adult"
     BOTH = "both"
-    null = None
+    null = "none"
 
 
-class Tricks(str, Enum):
+class Tricks(StrEnum):
     # General Tricks
     VISIBLE_COLLISION = "Visible Collision"
     GROTTOS_WITHOUT_AGONY = "Grottos Without Agony"

--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -1,15 +1,15 @@
-from typing import Dict, List, TYPE_CHECKING
+from typing import Dict, TYPE_CHECKING
 import math
 
 from .Enums import *
-from .Items import SohItem, item_data_table, filler_items, filler_bottles
+from .Items import item_data_table, filler_items, filler_bottles
 
 if TYPE_CHECKING:
     from . import SohWorld
 
 
 def create_item_pool(world: "SohWorld") -> None:
-    items_to_create: Dict[Enum, int] = {item: data.quantity_in_item_pool for item, data in item_data_table.items()}
+    items_to_create: Dict[str, int] = {item: data.quantity_in_item_pool for item, data in item_data_table.items()}
 
     filler_bottle_amount: int = 2
 
@@ -226,32 +226,32 @@ def create_item_pool(world: "SohWorld") -> None:
     # Add regular item pool
     for item, quantity in items_to_create.items():
         for _ in range(quantity):
-            world.item_pool.append(world.create_item(item.value))
+            world.item_pool.append(world.create_item(item))
 
     # Add random filler bottles
-    world.item_pool += [world.create_item(get_filler_bottle(world).value) for _ in range(filler_bottle_amount)]
+    world.item_pool += [world.create_item(get_filler_bottle(world)) for _ in range(filler_bottle_amount)]
 
     # Figure out Ice Trap amount with Options
     # Ice Trap Count
     open_location_count: int = sum(1 for loc in world.get_locations() if not loc.locked)
     filler_item_count: int = open_location_count - len(world.item_pool)
-    world.item_pool += [world.create_item(Items.ICE_TRAP.value) for _ in range(min(filler_item_count, world.options.ice_trap_count.value))]
+    world.item_pool += [world.create_item(Items.ICE_TRAP) for _ in range(min(filler_item_count, world.options.ice_trap_count.value))]
 
     #Ice Trap Filler Replacement
     open_location_count = sum(1 for loc in world.get_locations() if not loc.locked)
     filler_item_count = open_location_count - len(world.item_pool)
     places_to_fill: int = int(filler_item_count * (world.options.ice_trap_filler_replacement.value * .01))
-    world.item_pool += [world.create_item(Items.ICE_TRAP.value) for _ in range(places_to_fill)]
+    world.item_pool += [world.create_item(Items.ICE_TRAP) for _ in range(places_to_fill)]
 
     # Add junk items to fill remaining locations
     open_location_count = sum(1 for loc in world.get_locations() if not loc.locked)
     filler_item_count: int = open_location_count - len(world.item_pool)
-    world.item_pool += [world.create_item(get_filler_item(world).value) for _ in range(filler_item_count)]
+    world.item_pool += [world.create_item(get_filler_item(world)) for _ in range(filler_item_count)]
 
     world.multiworld.itempool += world.item_pool
 
-def get_filler_item(world: "SohWorld") -> Enum:
+def get_filler_item(world: "SohWorld") -> str:
     return world.random.choice(filler_items)
 
-def get_filler_bottle(world: "SohWorld") -> Enum:
+def get_filler_bottle(world: "SohWorld") -> str:
     return world.random.choice(filler_bottles)

--- a/worlds/oot_soh/Items.py
+++ b/worlds/oot_soh/Items.py
@@ -1,5 +1,4 @@
-from typing import Dict, NamedTuple, TYPE_CHECKING
-from enum import IntEnum
+from typing import Dict, NamedTuple
 from BaseClasses import Item, ItemClassification as IC
 from .Enums import *
 

--- a/worlds/oot_soh/Locations.py
+++ b/worlds/oot_soh/Locations.py
@@ -1,6 +1,6 @@
 from .Enums import Locations
 
-from typing import Dict, TYPE_CHECKING
+from typing import Dict
 
 from BaseClasses import Location
 

--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -31,13 +31,13 @@ class rule_wrapper:
 def add_locations(parent_region: Regions, world: "SohWorld",
                   locations: list[tuple[Locations, Callable[[tuple[CollectionState, Regions, "SohWorld"]], bool]]]) -> None:
     for location in locations:
-        locationName = location[0].value
+        locationName = location[0]
         locationRule = lambda bundle: True
         if len(location) > 1:
             locationRule = location[1]
         if locationName in world.included_locations:
             locationAddress = world.included_locations.pop(location[0])
-            world.get_region(parent_region.value).add_locations({locationName: locationAddress}, SohLocation)
+            world.get_region(parent_region).add_locations({locationName: locationAddress}, SohLocation)
             set_rule(world.get_location(locationName), rule_wrapper.wrap(parent_region, locationRule, world))
 
 
@@ -49,39 +49,39 @@ def connect_regions(parent_region: Regions, world: "SohWorld",
         regionRule = lambda bundle: True
         if len(region) > 1:
             regionRule = region[1]
-        world.get_region(parent_region.value).connect(world.get_region(regionName.value),
+        world.get_region(parent_region).connect(world.get_region(regionName),
                                                       rule=rule_wrapper.wrap(parent_region, regionRule, world))
 
 
 def add_events(parent_region: Regions, world: "SohWorld",
-               events: list[tuple[Enum, Events | Enum, Callable[[tuple[CollectionState, Regions, "SohWorld"]], bool]]]) -> None:
+               events: list[tuple[StrEnum, Events | StrEnum, Callable[[tuple[CollectionState, Regions, "SohWorld"]], bool]]]) -> None:
     for event in events:
-        event_location = event[0].value
-        event_item = event[1].value
+        event_location = event[0]
+        event_item = event[1]
         event_rule = event[2]
         
-        world.get_region(parent_region.value).add_locations({event_location: None}, SohLocation)
+        world.get_region(parent_region).add_locations({event_location: None}, SohLocation)
         world.get_location(event_location).place_locked_item(SohItem(event_item, IC.progression, None, world.player))
         set_rule(world.get_location(event_location), rule_wrapper.wrap(parent_region, event_rule, world))
 
 
-def can_use(item: Enum, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
+def can_use(item: Items, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     if not has_item(item, bundle):
         return False
 
     data = item_data_table
 
     if item in data:
-        if data[item.value].adult_only and not is_adult(bundle):
+        if data[item].adult_only and not is_adult(bundle):
             return False
 
-        if data[item.value].child_only and not is_child(bundle):
+        if data[item].child_only and not is_child(bundle):
             return False
         
-        if data[item.value].item_type == ItemType.magic and not has_item(Items.PROGRESSIVE_MAGIC_METER, bundle):
+        if data[item].item_type == ItemType.magic and not has_item(Items.PROGRESSIVE_MAGIC_METER, bundle):
             return False
 
-        if data[item.value].item_type == ItemType.song:
+        if data[item].item_type == ItemType.song:
             return can_play_song(item, bundle)
     
     if item in (Items.FIRE_ARROW, Items.ICE_ARROW, Items.LIGHT_ARROW):
@@ -99,14 +99,14 @@ def can_use(item: Enum, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> 
     return True
 
 
-def can_use_any(names: list[Enum], bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
+def can_use_any(names: list[Items], bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     for name in names:
         if can_use(name, bundle):
             return True
     return False
 
 
-def has_item(item: Items | Events | Enum, bundle: tuple[CollectionState, Regions, "SohWorld"], count: int = 1) -> bool:
+def has_item(item: Items | Events | StrEnum, bundle: tuple[CollectionState, Regions, "SohWorld"], count: int = 1) -> bool:
     state = bundle[0]
     world = bundle[2]
     player = world.player
@@ -115,22 +115,22 @@ def has_item(item: Items | Events | Enum, bundle: tuple[CollectionState, Regions
         return state.has_all((Events.CAN_FARM_STICKS, Items.DEKU_STICK_BAG), player)
     
     if item in (Items.PROGRESSIVE_BOMBCHU, Items.BOMBCHUS_5, Items.BOMBCHUS_10, Items.BOMBCHUS_20):
-        return (state.has_any((Items.BOMBCHUS_5.value, Items.BOMBCHUS_10.value, Items.BOMBCHUS_20.value,
-                               Items.PROGRESSIVE_BOMBCHU.value), world.player)
+        return (state.has_any((Items.BOMBCHUS_5, Items.BOMBCHUS_10, Items.BOMBCHUS_20,
+                               Items.PROGRESSIVE_BOMBCHU), world.player)
                 or (bombchus_enabled(bundle)
-                    and state.has_any((Items.BUY_BOMBCHUS10.value, Items.BUY_BOMBCHUS20.value, Events.COULD_PLAY_BOWLING.value, Events.CARPET_MERCHANT.value), world.player)))
+                    and state.has_any((Items.BUY_BOMBCHUS10, Items.BUY_BOMBCHUS20, Events.COULD_PLAY_BOWLING, Events.CARPET_MERCHANT), world.player)))
     
     if item == Items.NUTS:
         return state.has_all((Events.CAN_FARM_NUTS, Items.DEKU_NUT_BAG), player)
 
     if item == Items.MAGIC_BEAN:
-        return state.has_any({Items.MAGIC_BEAN_PACK.value, Events.CAN_BUY_BEANS.value}, player)
+        return state.has_any({Items.MAGIC_BEAN_PACK, Events.CAN_BUY_BEANS}, player)
     
     if item == Items.DEKU_SHIELD:
-        return state.has(Items.BUY_DEKU_SHIELD.value, player)
+        return state.has(Items.BUY_DEKU_SHIELD, player)
     
     if item == Items.HYLIAN_SHIELD:
-        return state.has(Items.BUY_HYLIAN_SHIELD.value, player)
+        return state.has(Items.BUY_HYLIAN_SHIELD, player)
     
     if item == Items.SCARECROW:
         return scarecrows_song(bundle) and can_use(Items.HOOKSHOT, bundle)
@@ -139,34 +139,34 @@ def has_item(item: Items | Events | Enum, bundle: tuple[CollectionState, Regions
         return scarecrows_song(bundle) and can_use(Items.LONGSHOT, bundle)
     
     if item == Items.FISHING_POLE:
-        return (not world.options.shuffle_fishing_pole) or state.has(Items.FISHING_POLE.value, player)
+        return (not world.options.shuffle_fishing_pole) or state.has(Items.FISHING_POLE, player)
     
     if item == Items.EPONA:
         return state.has(Events.FREED_EPONA, player)
 
     if item in (Items.POCKET_EGG, Items.COJIRO, Items.ODD_MUSHROOM, Items.ODD_POTION, Items.POACHERS_SAW, Items.BROKEN_GORONS_SWORD, Items.PRESCRIPTION, Items.EYEBALL_FROG, Items.WORLDS_FINEST_EYEDROPS):
-        return (not world.options.shuffle_adult_trade_items) or state.has(item.value, player)
+        return (not world.options.shuffle_adult_trade_items) or state.has(item, player)
     
     if item == Items.BOTTLE_WITH_BIG_POE:
-        return has_bottle(bundle) and state.has(Events.CAN_DEFEAT_BIG_POE.value, player)
+        return has_bottle(bundle) and state.has(Events.CAN_DEFEAT_BIG_POE, player)
     
     if item == Items.BOTTLE_WITH_BLUE_FIRE:
-        return has_bottle(bundle) and (state.has(Events.CAN_ACCESS_BLUE_FIRE.value, player) or state.has(Items.BUY_BLUE_FIRE.value, player))
+        return has_bottle(bundle) and (state.has(Events.CAN_ACCESS_BLUE_FIRE, player) or state.has(Items.BUY_BLUE_FIRE, player))
     
     if item == Items.BOTTLE_WITH_BLUE_POTION:
-        return has_bottle(bundle) and state.has(Items.BUY_BLUE_POTION.value, player)
+        return has_bottle(bundle) and state.has(Items.BUY_BLUE_POTION, player)
     
     if item == Items.BOTTLE_WITH_BUGS:
-        return has_bottle(bundle) and (state.has(Events.CAN_ACCESS_BUGS.value, player) or state.has(Items.BUY_BOTTLE_BUG.value, player))
+        return has_bottle(bundle) and (state.has(Events.CAN_ACCESS_BUGS, player) or state.has(Items.BUY_BOTTLE_BUG, player))
     
     if item == Items.BOTTLE_WITH_FAIRY:
-        return has_bottle(bundle) and (state.has(Events.CAN_ACCESS_FAIRIES.value, player) or state.has(Items.BUY_FAIRYS_SPIRIT.value, player))
+        return has_bottle(bundle) and (state.has(Events.CAN_ACCESS_FAIRIES, player) or state.has(Items.BUY_FAIRYS_SPIRIT, player))
     
     if item == Items.BOTTLE_WITH_FISH:
-        return has_bottle(bundle) and (state.has(Events.CAN_ACCESS_FISH.value, player) or state.has(Items.BUY_FISH.value, player))
+        return has_bottle(bundle) and (state.has(Events.CAN_ACCESS_FISH, player) or state.has(Items.BUY_FISH, player))
     
     if item == Items.BOTTLE_WITH_GREEN_POTION:
-        return has_bottle(bundle) and state.has(Items.BUY_GREEN_POTION.value, player)
+        return has_bottle(bundle) and state.has(Items.BUY_GREEN_POTION, player)
     
     if item == Items.BOTTLE_WITH_MILK:
         return has_bottle(bundle)
@@ -180,14 +180,14 @@ def has_item(item: Items | Events | Enum, bundle: tuple[CollectionState, Regions
     if item == Items.EMPTY_BOTTLE:
         return has_bottle(bundle)
 
-    return state.has(item.value, player, count)
+    return state.has(item, player, count)
         
 
 wallet_capacities: dict[str, int] = {
-    Items.CHILD_WALLET.value: 99,
-    Items.ADULT_WALLET.value: 200,
-    Items.GIANT_WALLET.value: 500,
-    Items.TYCOON_WALLET.value: 999
+    Items.CHILD_WALLET: 99,
+    Items.ADULT_WALLET: 200,
+    Items.GIANT_WALLET: 500,
+    Items.TYCOON_WALLET: 999
 }
 
 
@@ -221,17 +221,17 @@ def bottle_count(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> int:
     count = 0
     for bottle in no_rules_bottles:
         count += state.count(bottle.value, world.player)
-    if state.has(Events.DELIVER_LETTER.value, world.player):
-        count += state.count(Items.BOTTLE_WITH_RUTOS_LETTER.value, world.player)
-    if state.has(Events.CAN_EMPTY_BIG_POES.value, world.player):
-        count += state.count(Items.BOTTLE_WITH_BIG_POE.value, world.player)
+    if state.has(Events.DELIVER_LETTER, world.player):
+        count += state.count(Items.BOTTLE_WITH_RUTOS_LETTER, world.player)
+    if state.has(Events.CAN_EMPTY_BIG_POES, world.player):
+        count += state.count(Items.BOTTLE_WITH_BIG_POE, world.player)
     return count
 
 
 def bombchu_refill(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     state = bundle[0]
     world = bundle[2]
-    return state.has_any([Items.BUY_BOMBCHUS10.value, Items.BUY_BOMBCHUS20.value, Events.COULD_PLAY_BOWLING.value, Events.CARPET_MERCHANT.value], world.player) or bool(world.options.bombchu_drops)
+    return state.has_any([Items.BUY_BOMBCHUS10, Items.BUY_BOMBCHUS20, Events.COULD_PLAY_BOWLING, Events.CARPET_MERCHANT], world.player) or bool(world.options.bombchu_drops)
 
 
 def bombchus_enabled(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
@@ -242,22 +242,22 @@ def bombchus_enabled(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> boo
 
 
 ocarina_buttons_required: dict[str, list[str]] = {
-    Items.ZELDAS_LULLABY.value: [Items.OCARINA_CLEFT_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value,Items.OCARINA_CUP_BUTTON.value],
-    Items.EPONAS_SONG.value: [Items.OCARINA_CLEFT_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CUP_BUTTON.value],
-    Items.PRELUDE_OF_LIGHT.value: [Items.OCARINA_CLEFT_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CUP_BUTTON.value],
-    Items.SARIAS_SONG.value: [Items.OCARINA_CLEFT_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CDOWN_BUTTON.value],
-    Items.SUNS_SONG.value: [Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CUP_BUTTON.value, Items.OCARINA_CDOWN_BUTTON.value],
-    Items.SONG_OF_TIME.value: [Items.OCARINA_A_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CDOWN_BUTTON.value],
-    Items.BOLERO_OF_FIRE.value: [Items.OCARINA_A_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CDOWN_BUTTON.value],
-    Items.REQUIEM_OF_SPIRIT.value: [Items.OCARINA_A_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CDOWN_BUTTON.value],
-    Items.SONG_OF_STORMS.value: [Items.OCARINA_A_BUTTON.value, Items.OCARINA_CUP_BUTTON.value, Items.OCARINA_CDOWN_BUTTON.value],
-    Items.MINUET_OF_FOREST.value: [Items.OCARINA_A_BUTTON.value, Items.OCARINA_CLEFT_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CUP_BUTTON.value],
-    Items.SERENADE_OF_WATER.value: [Items.OCARINA_A_BUTTON.value, Items.OCARINA_CLEFT_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CDOWN_BUTTON.value],
-    Items.NOCTURNE_OF_SHADOW.value: [Items.OCARINA_A_BUTTON.value, Items.OCARINA_CLEFT_BUTTON.value, Items.OCARINA_CRIGHT_BUTTON.value, Items.OCARINA_CDOWN_BUTTON.value],
+    Items.ZELDAS_LULLABY: [Items.OCARINA_CLEFT_BUTTON, Items.OCARINA_CRIGHT_BUTTON,Items.OCARINA_CUP_BUTTON],
+    Items.EPONAS_SONG: [Items.OCARINA_CLEFT_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CUP_BUTTON],
+    Items.PRELUDE_OF_LIGHT: [Items.OCARINA_CLEFT_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CUP_BUTTON],
+    Items.SARIAS_SONG: [Items.OCARINA_CLEFT_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CDOWN_BUTTON],
+    Items.SUNS_SONG: [Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CUP_BUTTON, Items.OCARINA_CDOWN_BUTTON],
+    Items.SONG_OF_TIME: [Items.OCARINA_A_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CDOWN_BUTTON],
+    Items.BOLERO_OF_FIRE: [Items.OCARINA_A_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CDOWN_BUTTON],
+    Items.REQUIEM_OF_SPIRIT: [Items.OCARINA_A_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CDOWN_BUTTON],
+    Items.SONG_OF_STORMS: [Items.OCARINA_A_BUTTON, Items.OCARINA_CUP_BUTTON, Items.OCARINA_CDOWN_BUTTON],
+    Items.MINUET_OF_FOREST: [Items.OCARINA_A_BUTTON, Items.OCARINA_CLEFT_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CUP_BUTTON],
+    Items.SERENADE_OF_WATER: [Items.OCARINA_A_BUTTON, Items.OCARINA_CLEFT_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CDOWN_BUTTON],
+    Items.NOCTURNE_OF_SHADOW: [Items.OCARINA_A_BUTTON, Items.OCARINA_CLEFT_BUTTON, Items.OCARINA_CRIGHT_BUTTON, Items.OCARINA_CDOWN_BUTTON],
 }
 
 
-def can_play_song(song: Enum, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
+def can_play_song(song: StrEnum, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     state = bundle[0]
     world = bundle[2]
     if not has_item(Items.FAIRY_OCARINA, bundle):
@@ -265,7 +265,7 @@ def can_play_song(song: Enum, bundle: tuple[CollectionState, Regions, "SohWorld"
     if not world.options.shuffle_ocarina_buttons:
         return True
     else:
-        return state.has_all(ocarina_buttons_required[song.value], world.player)
+        return state.has_all(ocarina_buttons_required[song], world.player)
 
 
 def has_explosives(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
@@ -580,7 +580,7 @@ def can_kill_enemy(bundle: tuple[CollectionState, Regions, "SohWorld"], enemy: E
 
     if enemy == Enemies.BLUE_BUBBLE:
         return blast_or_smash(bundle) or can_use(Items.FAIRY_BOW, bundle) or \
-            ((can_jump_slash_except_hammer(bundle) or can_use(Items.FAIRY_SLINGSHOT, bundle)) and \
+            ((can_jump_slash_except_hammer(bundle) or can_use(Items.FAIRY_SLINGSHOT, bundle)) and
              (can_use(Items.NUTS, bundle) or hookshot_or_boomerang(bundle) or can_standing_shield(bundle)))
 
     if enemy == Enemies.DEAD_HAND:
@@ -616,7 +616,7 @@ def can_kill_enemy(bundle: tuple[CollectionState, Regions, "SohWorld"], enemy: E
     if enemy == Enemies.FLARE_DANCER:
         return can_use(Items.MEGATON_HAMMER, bundle) or \
                can_use(Items.HOOKSHOT, bundle) or \
-               (has_explosives(bundle) and (can_jump_slash_except_hammer(bundle) or can_use(Items.FAIRY_BOW, bundle) or \
+               (has_explosives(bundle) and (can_jump_slash_except_hammer(bundle) or can_use(Items.FAIRY_BOW, bundle) or
                     can_use(Items.FAIRY_SLINGSHOT, bundle) or can_use(Items.BOOMERANG, bundle)))
 
     if enemy in [Enemies.WOLFOS, Enemies.WHITE_WOLFOS, Enemies.WALLMASTER]:
@@ -694,7 +694,7 @@ def can_kill_enemy(bundle: tuple[CollectionState, Regions, "SohWorld"], enemy: E
     if enemy == Enemies.BONGO_BONGO:
         return has_boss_soul(Items.BONGO_BONGOS_SOUL, bundle) and \
                (can_use(Items.LENS_OF_TRUTH, bundle) or can_do_trick(Tricks.LENS_BONGO, bundle)) and can_use_sword(bundle) and \
-               (can_use(Items.HOOKSHOT, bundle) or can_use(Items.FAIRY_BOW, bundle) or can_use(Items.FAIRY_SLINGSHOT, bundle) or \
+               (can_use(Items.HOOKSHOT, bundle) or can_use(Items.FAIRY_BOW, bundle) or can_use(Items.FAIRY_SLINGSHOT, bundle) or
                 can_do_trick(Tricks.SHADOW_BONGO, bundle))
     if enemy == Enemies.TWINROVA:
         return has_boss_soul(Items.TWINROVAS_SOUL, bundle) and can_use(Items.MIRROR_SHIELD, bundle) and \
@@ -815,7 +815,7 @@ def small_keys(key: Items, requiredAmount: int, bundle: tuple[CollectionState, R
     if has_item(Items.SKELETON_KEY, bundle) or (world.options.key_rings.value and has_key_ring(key, bundle)):
         return True
 
-    return (state.has(key.value, world.player, requiredAmount))
+    return (state.has(key, world.player, requiredAmount))
 
 
 def has_key_ring(key : Items, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
@@ -941,7 +941,7 @@ def water_timer(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> int:
 def hearts(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> int:
     state = bundle[0]
     world = bundle[2]
-    return 3 + state.count(Items.HEART_CONTAINER.value, world.player) + (state.count(Items.PIECE_OF_HEART.value, world.player) // 4)
+    return 3 + state.count(Items.HEART_CONTAINER, world.player) + (state.count(Items.PIECE_OF_HEART, world.player) // 4)
 
 
 def can_open_bomb_grotto(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
@@ -1007,7 +1007,7 @@ def can_build_rainbow_bridge(bundle: tuple[CollectionState, Regions, "SohWorld"]
 def get_gs_count(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> int:
     state = bundle[0]
     world = bundle[2]
-    return state.count(Items.GOLD_SKULLTULA_TOKEN.value, world.player)
+    return state.count(Items.GOLD_SKULLTULA_TOKEN, world.player)
 
 
 def can_trigger_lacs(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:

--- a/worlds/oot_soh/Regions.py
+++ b/worlds/oot_soh/Regions.py
@@ -101,7 +101,7 @@ def create_regions_and_locations(world: "SohWorld") -> None:
     # Fill region data table based on the regions enum list
     region_data_table: Dict[str, SohRegionData] = {}
     for entry in Regions:
-        region_data_table[entry.value] = SohRegionData([])
+        region_data_table[entry] = SohRegionData([])
 
     # Create regions.
     for region_name in region_data_table.keys():
@@ -234,7 +234,7 @@ def create_regions_and_locations(world: "SohWorld") -> None:
     # Place any locations that still don't have a region in the ROOT region.
     # TODO should be removed when logic is done
     for location_name, location_address in world.included_locations.items():
-        world.get_region(Regions.ROOT.value).add_locations({location_name: location_address}, SohLocation)
+        world.get_region(Regions.ROOT).add_locations({location_name: location_address}, SohLocation)
 
 # Create a dictionary mapping blue warp rewards to their vanilla items
 dungeon_reward_item_mapping = {
@@ -253,19 +253,19 @@ def place_locked_items(world: "SohWorld") -> None:
     
     # Add Weird Egg and Zelda's Letter to their vanilla locations when not shuffled
     if not world.options.skip_child_zelda and not world.options.shuffle_weird_egg:
-        world.get_location(Locations.HC_MALON_EGG.value).place_locked_item(world.create_item(Items.WEIRD_EGG.value))
+        world.get_location(Locations.HC_MALON_EGG).place_locked_item(world.create_item(Items.WEIRD_EGG))
 
     if not world.options.skip_child_zelda:
-        world.get_location(Locations.HC_ZELDAS_LETTER.value).place_locked_item(world.create_item(Items.ZELDAS_LETTER.value))
+        world.get_location(Locations.HC_ZELDAS_LETTER).place_locked_item(world.create_item(Items.ZELDAS_LETTER))
 
     # Place Master Sword on vanilla location if not shuffled
     if not world.options.shuffle_master_sword:
-        world.get_location(Locations.MARKET_TOT_MASTER_SWORD.value).place_locked_item(world.create_item(Items.MASTER_SWORD.value))
+        world.get_location(Locations.MARKET_TOT_MASTER_SWORD).place_locked_item(world.create_item(Items.MASTER_SWORD))
 
     # Handle vanilla goron tunic in shop
     # TODO: Proper implementation of vanilla shop items and shuffle them amongst all shops
     if world.options.shuffle_shops:
-        world.get_location(Locations.GC_SHOP_ITEM1.value).place_locked_item(world.create_item(Items.BUY_GORON_TUNIC.value))
+        world.get_location(Locations.GC_SHOP_ITEM1).place_locked_item(world.create_item(Items.BUY_GORON_TUNIC))
 
     # Preplace dungeon rewards in vanilla locations when not shuffled
     if world.options.shuffle_dungeon_rewards == "off":      
@@ -275,19 +275,19 @@ def place_locked_items(world: "SohWorld") -> None:
 
     # Place Ganons Boss Key
     if not world.options.ganons_castle_boss_key == "vanilla" and not world.options.ganons_castle_boss_key == "anywhere" and not world.options.triforce_hunt:
-        world.get_location(Locations.MARKET_TOT_LIGHT_ARROW_CUTSCENE.value).place_locked_item(world.create_item(Items.GANONS_CASTLE_BOSS_KEY.value))
+        world.get_location(Locations.MARKET_TOT_LIGHT_ARROW_CUTSCENE).place_locked_item(world.create_item(Items.GANONS_CASTLE_BOSS_KEY))
 
     if world.options.ganons_castle_boss_key == "vanilla" and not world.options.triforce_hunt:
-        world.get_location(Locations.GANONS_CASTLE_TOWER_BOSS_KEY_CHEST.value).place_locked_item(world.create_item(Items.GANONS_CASTLE_BOSS_KEY.value))
+        world.get_location(Locations.GANONS_CASTLE_TOWER_BOSS_KEY_CHEST).place_locked_item(world.create_item(Items.GANONS_CASTLE_BOSS_KEY))
 
     # Preplace tokens based on settings.
     if world.options.shuffle_skull_tokens == "off" or world.options.shuffle_skull_tokens == "dungeon":
-        token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN.value)
+        token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN)
         for location_name, address in gold_skulltula_overworld_location_table.items():
             world.get_location(location_name).place_locked_item(token_item)
 
     if world.options.shuffle_skull_tokens == "off" or world.options.shuffle_skull_tokens == "overworld":
-        token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN.value)
+        token_item = world.create_item(Items.GOLD_SKULLTULA_TOKEN)
         for location_name, address in gold_skulltula_dungeon_location_table.items():
             world.get_location(location_name).place_locked_item(token_item)
 

--- a/worlds/oot_soh/ShopItems.py
+++ b/worlds/oot_soh/ShopItems.py
@@ -1,9 +1,8 @@
 from typing import List, Dict, TYPE_CHECKING
 from worlds.generic.Rules import add_rule
 from .LogicHelpers import rule_wrapper, can_afford
-from Fill import fill_restrictive, FillError
-from BaseClasses import MultiWorld, CollectionState
-from .Regions import dungeon_reward_item_mapping
+from Fill import fill_restrictive
+from BaseClasses import CollectionState
 
 from .Enums import *
 
@@ -171,7 +170,7 @@ def fill_shop_items(world: "SohWorld") -> None:
         vanilla_shop_slots += list(shop.keys())[0: num_vanilla]
 
     vanilla_shop_locations = [world.get_location(slot) for slot in vanilla_shop_slots]
-    vanilla_items = [world.create_item(item.value) for item in vanilla_pool]
+    vanilla_items = [world.create_item(item) for item in vanilla_pool]
 
     # create a filled copy of the state so the multiworld can place the vanilla shop items using logic
     prefill_state = CollectionState(world.multiworld)
@@ -200,7 +199,7 @@ def no_shop_shuffle(world: "SohWorld") -> None:
     for region, shop in all_shop_locations:
         for slot, item in shop.items():
             world.shop_prices[slot] = vanilla_shop_prices[item]
-            world.get_location(slot).place_locked_item(world.create_item(item.value))
+            world.get_location(slot).place_locked_item(world.create_item(item))
             world.get_location(slot).address = None
             world.shop_vanilla_items[slot] = item.value
 

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -67,13 +67,13 @@ class SohWorld(World):
         # when adding another progressive item that is option-dependent like these,
         # be sure to also update LogicHelpers.increment_current_count with it too
         if not self.options.shuffle_swim:
-            self.push_precollected(self.create_item(Items.BRONZE_SCALE.value))
+            self.push_precollected(self.create_item(Items.BRONZE_SCALE))
         if not self.options.shuffle_deku_stick_bag:
-            self.push_precollected(self.create_item(Items.DEKU_STICK_BAG.value))
+            self.push_precollected(self.create_item(Items.DEKU_STICK_BAG))
         if not self.options.shuffle_deku_nut_bag:
-            self.push_precollected(self.create_item(Items.DEKU_NUT_BAG.value))
+            self.push_precollected(self.create_item(Items.DEKU_NUT_BAG))
         if not self.options.bombchu_bag:
-            self.push_precollected(self.create_item(Items.BOMBCHU_BAG.value))
+            self.push_precollected(self.create_item(Items.BOMBCHU_BAG))
         
         create_item_pool(self)
 
@@ -94,7 +94,7 @@ class SohWorld(World):
                 prefill_state.collect(item, False)
             for region, shop in all_shop_locations:
                 for slot, item in shop.items():
-                    prefill_state.collect(self.create_item(item.value), False)
+                    prefill_state.collect(self.create_item(item), False)
             prefill_state.sweep_for_advancements()
 
             dungeon_reward_locations = [self.get_location(location.value) for location in dungeon_reward_item_mapping.keys()]

--- a/worlds/oot_soh/location_access/dungeons/bottom_of_the_well.py
+++ b/worlds/oot_soh/location_access/dungeons/bottom_of_the_well.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     BOTTOM_OF_THE_WELL_LOWERED_WATER = "Bottom of the Well Lowered Water"
     BOTTOM_OF_THE_WELL_NUT_POT = "Bottom of the Well Nut Pot"
     BOTTOM_OF_THE_WELL_STICK_POT = "Bottom of the Well Stick Pot"
@@ -11,7 +11,7 @@ class EventLocations(str, Enum):
     BOTTOM_OF_THE_WELL_BABAS_NUTS = "Bottom of the Well Deku Baba Nuts"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     LOWERED_WATER_INSIDE_BOTTOM_OF_THE_WELL = "Water was lowered in the Bottom of the Well"
 
 

--- a/worlds/oot_soh/location_access/dungeons/deku_tree.py
+++ b/worlds/oot_soh/location_access/dungeons/deku_tree.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     DEKU_TREE_LOBBY_BABA_STICKS = "Deku Tree Lobby Baba Sticks",
     DEKU_TREE_LOBBY_BABA_NUTS = "Deku Tree Lobby Baba Nuts",
     DEKU_TREE_COMPASS_BABA_STICKS = "Deku Tree Compass Room Baba Sticks",
@@ -20,7 +20,7 @@ class EventLocations(str, Enum):
     DEKU_TREE_QUEEN_GOHMA = "Deku Tree Queen Gohma"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     DEKU_TREE_BASEMENT_UPPER_BLOCK_PUSHED = "Deku Tree Basement Upper Block Pushed"
 
 

--- a/worlds/oot_soh/location_access/dungeons/dodongos_cavern.py
+++ b/worlds/oot_soh/location_access/dungeons/dodongos_cavern.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     DODONGOS_CAVERN_GOSSIP_STONE_SONG_FAIRY = "Dodongos Cavern Gossip Stone Song Fairy"
     DODONGOS_CAVERN_LOBBY_SWITCH = "Dodongos Cavern Lobby Switch",
     DODONGOS_CAVERN_LOWER_LIZALFOS_FIGHT = "Dodongos Cavern Lower Lizalfos Fight"
@@ -13,7 +13,7 @@ class EventLocations(str, Enum):
     DODONGOS_CAVERN_KING_DODONGO = "Dodongos Cavern King Dodongo"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     DODONGOS_CAVERN_STAIRS_ROOM_DOOR = "Dodongos Cavern Stairs Room Door"
     DODONGOS_CAVERN_LIFT_PLATFORM = "Dodongos Cavern Lift Platform"
     DODONGOS_CAVERN_EYES_LIT = "Dodongos Cavern Eyes Lit"

--- a/worlds/oot_soh/location_access/dungeons/fire_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/fire_temple.py
@@ -3,14 +3,14 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
     
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     FIRE_TEMPLE_NEAR_BOSS_ROOM_FAIRY_POT = "Fire Temple Near Boss Room Fairy Pot"
     FIRE_TEMPLE_LOOP_HAMMER_SWITCH_ROOM_SWITCH = "Fire Temple Loop Hammer Switch Room Switch"
     FIRE_TEMPLE_FIRE_MAZE_UPPER_PLATFORM = "Fire Temple Fire Maze Upper Platform"
     FIRE_TEMPLE_VOLVAGIA = "Fire Temple Volvagia"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     FIRE_TEMPLE_LOOP_HAMMER_SWITCH_HIT = "Fire Temple Loop Hammer Switch Hit"
     FIRE_TEMPLE_FIRE_MAZE_UPPER_PLATFORM_HIT = "Fire Temple Fire Maze Upper Platform Hit"
 

--- a/worlds/oot_soh/location_access/dungeons/forest_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/forest_temple.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
     
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     FOREST_TEMPLE_MEG = "Forest Temple Meg"
     FOREST_TEMPLE_JOELLE = "Forest Temple Joelle"
     FOREST_TEMPLE_AMY = "Forest Temple Amy"
@@ -21,7 +21,7 @@ class EventLocations(str, Enum):
     FOREST_TEMPLE_PHANTOM_GANON = "Forest Temple Phantom Ganon"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     DEFEATED_MEG = "Defeated Meg"
     DEFEATED_JOELLE = "Defeated Joelle"
     DEFEATED_AMY = "Defeated Amy"

--- a/worlds/oot_soh/location_access/dungeons/ganons_castle.py
+++ b/worlds/oot_soh/location_access/dungeons/ganons_castle.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     GANONS_CASTLE_FREE_FAIRIES = "Ganon's Castle Free Fairies"
     GANONS_CASTLE_FOREST_TRIAL_AREA = "Ganon's Castle Forest Trial Area"
     GANONS_CASTLE_FIRE_TRIAL_AREA = "Ganon's Castle Fire Trial Area"
@@ -17,7 +17,7 @@ class EventLocations(str, Enum):
     GANON_DEFEATED = "Ganon Defeated"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     GANONS_CASTLE_FOREST_TRIAL_CLEARED = "Ganon's Castle Forest Trial Cleared"
     GANONS_CASTLE_FIRE_TRIAL_CLEARED = "Ganon's Castle Fire Trial Cleared"
     GANONS_CASTLE_WATER_TRIAL_CLEARED = "Ganon's Castle Water Trial Cleared"

--- a/worlds/oot_soh/location_access/dungeons/ice_cavern.py
+++ b/worlds/oot_soh/location_access/dungeons/ice_cavern.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     ICE_CAVERN_BLUE_FIRE_ACCESS = "Ice Cavern Blue Fire Access"
 
 

--- a/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
+++ b/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     JABU_JABUS_BELLY_WEST_TENTACLE = "Jabu Jabus Belly West Tentacle"
     JABU_JABUS_BELLY_EAST_TENTACLE = "Jabu Jabus Belly East Tentacle"
     JABU_JABUS_BELLY_NORTH_TENTACLE = "Jabu Jabus Belly North Tentacle"
@@ -16,7 +16,7 @@ class EventLocations(str, Enum):
     JABU_JABUS_BELLY_BARINADE = "Jabu Jabus Belly Barinade"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     JABU_JABUS_BELLY_WEST_TENTACLE_DEFEATED = "Jabu Jabus Belly West Tentacle Defeated"
     JABU_JABUS_BELLY_EAST_TENTACLE_DEFEATED = "Jabu Jabus Belly East Tentacle Defeated"
     JABU_JABUS_BELLY_NORTH_TENTACLE_DEFEATED = "Jabu Jabus Belly North Tentacle Defeated"

--- a/worlds/oot_soh/location_access/dungeons/shadow_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/shadow_temple.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     SHADOW_TEMPLE_BEGINNING_NUT_POT = "Shadow Temple Beginning Nut Pot"
     SHADOW_TEMPLE_FAIRY_POT = "Shadow Temple Fairy Pot"
     SHADOW_TEMPLE_BONGO_BONGO = "Shadow Temple Bongo Bongo"

--- a/worlds/oot_soh/location_access/dungeons/spirit_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/spirit_temple.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     SPIRIT_TEMPLE_BEGINNING_NUT_CRATE = "Spirit Temple Nut Crate"
     SPIRIT_TEMPLE_TWINROVA = "Spirit Temple Twinrova"
 

--- a/worlds/oot_soh/location_access/dungeons/water_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/water_temple.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
     
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     WATER_TEMPLE_EAST_LOWER_WATER_LOW_FROM_HIGH = "Water Temple East Lower Water Low From High"
     WATER_TEMPLE_CENTRAL_PILLAR_UPPER_WATER_MIDDLE = "Water Temple Central Pillar Upper Water Middle"
     WATER_TEMPLE_HIGH_WATER_WATER_HIGH = "Water Temple High Water Water High"
@@ -12,7 +12,7 @@ class EventLocations(str, Enum):
     WATER_TEMPLE_MORPHA = "Water Temple Morpha"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     WATER_LEVEL_LOW = "Water Level Low"
     WATER_LEVEL_MIDDLE = "Water Level Middle"
     WATER_LEVEL_HIGH = "Water Level High"

--- a/worlds/oot_soh/location_access/overworld/castle_grounds.py
+++ b/worlds/oot_soh/location_access/overworld/castle_grounds.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     HC_GOSSIP_STONE_SONG_FAIRY = "HC Gossip Stone Song Fairy"
     HC_BUTTERFLY_FAIRY = "HC Butterfly Fairy"
     HC_BUG_ROCK = "HC Bug Rock"
@@ -13,7 +13,7 @@ class EventLocations(str, Enum):
     HC_OGC_RAINBOW_BRIDGE = "HC OGC Rainbow Bridge"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     HC_OGC_RAINBOW_BRIDGE_BUILT = "HC OGC Rainbow Bridge Built"
 
 

--- a/worlds/oot_soh/location_access/overworld/death_mountain_crater.py
+++ b/worlds/oot_soh/location_access/overworld/death_mountain_crater.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     DMC_GOSSIP_STONE_SONG_FAIRY = "DMC Gossip Stone Song Fairy"
     DMC_BEAN_PLANT_FAIRY = "DMC Bean Plant Fairy"
     DMC_UPPER_GROTTO_GOSSIP_STONE_SONG_FAIRY = "DMC Upper Grotto Gossip Stone Song Fairy"
@@ -12,7 +12,7 @@ class EventLocations(str, Enum):
     DMC_UPPER_GROTTO_PUDDLE_FISH = "DMC Upper Grotto Puddle Fish"
     DMC_BEAN_PATCH = "DMC Bean Patch"
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     DMC_BEAN_PLANTED = "DMC Bean Planted"
 
 

--- a/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
+++ b/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     DMT_BEAN_PLANT_FAIRY = "DMT Bean Plant Fairy"
     DMT_GOSSIP_STONE_SONG_FAIRY = "DMT Gossip Stone Song Fairy"
     DMT_BUG_ROCK = "DMT Bug Rock"
@@ -13,7 +13,7 @@ class EventLocations(str, Enum):
     DMT_STORMS_GROTTO_PUDDLE_FISH = "DMT Storms Grotto Puddle Fish"
     DMT_BEAN_PATCH = "DMT Bean Patch"
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     DMT_BEAN_PLANTED = "DMT Bean Planted"
 
 

--- a/worlds/oot_soh/location_access/overworld/desert_colossus.py
+++ b/worlds/oot_soh/location_access/overworld/desert_colossus.py
@@ -3,13 +3,13 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     DESERT_COLOSSUS_FAIRY_POND_COLOSSUS = "Desert Colossus Fairy Pond Colossus"
     DESERT_COLOSSUS_FAIRY_POND_OASIS = "Desert Colossus Fairy Pond Oasis"
     DESERT_COLOSSUS_BUG_ROCK = "Desert Colossus Bug Rock"
     DESERT_COLOSSUS_BEAN_PATCH = "Desert Colossus Bean Patch"
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     DESERT_COLOSSUS_BEAN_PLANTED = "Desert Colossus Bean Planted"
 
 

--- a/worlds/oot_soh/location_access/overworld/gerudo_fortress.py
+++ b/worlds/oot_soh/location_access/overworld/gerudo_fortress.py
@@ -4,14 +4,14 @@ if TYPE_CHECKING:
     from ... import SohWorld
 
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     GF_GATE = "GF Gate"
     GF_GATE_OUTSIDE = "GF Gate Outside"
     GTG_GATE = "GTG Gate"
     GF_STORMS_GROTTO_FAIRY = "GF Storms Grotto Fairy"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     GF_GATE_OPEN = "GF Gate Open"
     GTG_GATE_OPEN = "GTG Gate Open"
 

--- a/worlds/oot_soh/location_access/overworld/gerudo_valley.py
+++ b/worlds/oot_soh/location_access/overworld/gerudo_valley.py
@@ -4,13 +4,13 @@ if TYPE_CHECKING:
     from ... import SohWorld
 
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     GV_BUG_ROCK = "GV Bug Rock"
     GV_GOSSIP_STONE_SONG_FAIRY = "GV Gossip Stone Song Fairy"
     GV_BEAN_SOIL = "GV Bean Soil"
     GV_BEAN_PATCH = "GV Bean Patch"
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     GV_BEAN_PLANTED = "GV Bean Planted"
 
 

--- a/worlds/oot_soh/location_access/overworld/goron_city.py
+++ b/worlds/oot_soh/location_access/overworld/goron_city.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     GC_GOSSIP_STONE_SONG_FAIRY = "GC Gossip Stone Song Fairy"
     GC_STICK_POT = "GC Stick Pot"
     GC_BUG_ROCK = "GC Bug Rock"
@@ -15,7 +15,7 @@ class EventLocations(str, Enum):
     GC_STOP_ROLLING_GORON_AS_ADULT = "GC Stop Rolling Goron as Adult"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     GC_CHILD_FIRE_LIT = "GC Child Fire Lit"
     GC_WOODS_WARP_OPEN = "GC Woods Warp Open"
     GC_DARUNIAS_DOOR_OPENED_AS_CHILD = "GC Darunias Door Opened as Child"

--- a/worlds/oot_soh/location_access/overworld/graveyard.py
+++ b/worlds/oot_soh/location_access/overworld/graveyard.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     GRAVEYARD_BUTTERFLY_FAIRY = "Graveyard Butterfly Fairy"
     GRAVEYARD_BEAN_PLANT_FAIRY = "Graveyard Bean Plant Fairy"
     GRAVEYARD_BUG_ROCK = "Graveyard Bug Rock"
@@ -14,7 +14,7 @@ class EventLocations(str, Enum):
     GRAVEYARD_BEAN_PATCH = "Graveyard Bean Patch"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     ACCESS_TO_WINDMILL_FROM_DAMPES_GRAVE = "Access to Windmill From Dampes Grave"
     GRAVEYARD_BEAN_PLANTED = "Graveyard Bean Planted"
 

--- a/worlds/oot_soh/location_access/overworld/haunted_wasteland.py
+++ b/worlds/oot_soh/location_access/overworld/haunted_wasteland.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     WASTELAND_FAIRY_POT = "Wasteland Fairy Pot"
     WASTELAND_NUT_POT = "Wasteland Nut Pot"
     WASTELAND_CARPET_SALESMAN_STORE = "Wasteland Carpet Salesman Store"

--- a/worlds/oot_soh/location_access/overworld/hyrule_field.py
+++ b/worlds/oot_soh/location_access/overworld/hyrule_field.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
     
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     HF_BIG_POE = "HF Big Poe"
     HF_RUNNING_MAN = "HF Running Man"
     HF_COW_GROTTO_BEHIND_WEBS_GOSSIP_STONE_SONG_FAIRY = "HF Cow Grotto Behind Webs Gossip Stone Song Fairy"

--- a/worlds/oot_soh/location_access/overworld/kakariko.py
+++ b/worlds/oot_soh/location_access/overworld/kakariko.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from ... import SohWorld
 
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     KAK_GATE = "Kak Gate"
     KAK_GATE_GUARD = "Kak Gate Guard"
     KAK_BUG_ROCK = "Kak Bug Rock"
@@ -16,7 +16,7 @@ class EventLocations(str, Enum):
     KAK_OPEN_GROTTO_PUDDLE_FISH = "Kak Open Grotto Puddle Fish"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     WAKE_UP_ADULT_TALON = "Wake Up Talon As Adult"
 
 

--- a/worlds/oot_soh/location_access/overworld/kokiri_forest.py
+++ b/worlds/oot_soh/location_access/overworld/kokiri_forest.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from ... import SohWorld
 
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     MIDO = "Mido"
     MIDO_FROM_OUTSIDE_DEKU_TREE = "Mido From Outside Deku Tree"
     KF_GOSSIP_STONE_SONG_FAIRY = "KF Gossip Stone Song Fairy"
@@ -18,7 +18,7 @@ class EventLocations(str, Enum):
     KF_STORMS_GROTTO_PUDDLE_FISH = "KF Storms Grotto Puddle Fish"
     
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     MIDO_SWORD_AND_SHIELD = "Showed Mido the Sword and Shield"
     KF_BEAN_PLANTED = "KF Bean Planted"
 

--- a/worlds/oot_soh/location_access/overworld/lake_hylia.py
+++ b/worlds/oot_soh/location_access/overworld/lake_hylia.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     LH_BUG_SHRUB = "LH Bug Shrub"
     LH_BEAN_FAIRY = "LH Bean Fairy"
     LH_GOSSIP_STONE_SONG_FAIRY = "LH Gossip Stone Song Fairy"
@@ -13,7 +13,7 @@ class EventLocations(str, Enum):
     LH_BEAN_PATCH = "LH Bean Patch"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     LH_BEAN_PLANTED = "Lake Hylia Bean Planted"
 
 

--- a/worlds/oot_soh/location_access/overworld/lon_lon_ranch.py
+++ b/worlds/oot_soh/location_access/overworld/lon_lon_ranch.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from ... import SohWorld
 
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     LLR_TALON_RACE = "LLR Talon Race"
     LLR_TIME_TRIAL = "LLR Time Trial"
 

--- a/worlds/oot_soh/location_access/overworld/lost_woods.py
+++ b/worlds/oot_soh/location_access/overworld/lost_woods.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     LW_GOSSIP_STONE_SONG_FAIRY = "LW Gossip Stone Song Fairy"
     LW_BEAN_PLANT_FAIRY = "LW Bean Plant Fairy"
     LW_BUG_GRASS = "LW Bug Grass"
@@ -16,7 +16,7 @@ class EventLocations(str, Enum):
     LW_BRIDGE_BEAN_PATCH = "LW Bridge Bean Patch"
     LW_THEATER_BEAN_PATCH = "LW Theater Bean Patch"
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     LW_BRIDGE_BEAN_PLANTED = "LW Bridge Bean Planted"
     LW_THEATER_BEAN_PLANTED = "LW Theater Bean Planted"
 

--- a/worlds/oot_soh/location_access/overworld/market.py
+++ b/worlds/oot_soh/location_access/overworld/market.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
     
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     MARKET_GUARD_HOUSE = "Market Guard House"
     MARKET_MASK_SHOP_MASKS = "Market Mask Shop Masks"
     MARKET_MASK_SHOP_SKULL_MASK = "Market Mask Shop Skull Mask"

--- a/worlds/oot_soh/location_access/overworld/sacred_forest_meadow.py
+++ b/worlds/oot_soh/location_access/overworld/sacred_forest_meadow.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     SFM_GOSSIP_STONE_SONG_FAIRY = "SFM Gossip Stone Song Fairy"
     SFM_FAIRY_FOUNTAIN_FAIRY = "SFM Fairy Fountain Fairy"
 

--- a/worlds/oot_soh/location_access/overworld/temple_of_time.py
+++ b/worlds/oot_soh/location_access/overworld/temple_of_time.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     TOT_ENTRANCE_GOSSIP_STONE_SONG_FAIRY = "ToT Entrance Gossip Stone Fairy"
     MASTER_SWORD_PEDESTAL = "Master Sword Pedestal"
 

--- a/worlds/oot_soh/location_access/overworld/thieves_hideout.py
+++ b/worlds/oot_soh/location_access/overworld/thieves_hideout.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventsLocations(str, Enum):
+class EventsLocations(StrEnum):
     TH_1_TORCH_CARPENTER_CELL = "TH 1 Torch Carpenter Cell"
     TH_DOUBLE_CELL_CARPENTER_CELL = "TH Double Cell Carpenter Cell"
     TH_DEAD_END_CARPENTER_CELL = "TH Dead End Carpenter Cell"
@@ -11,7 +11,7 @@ class EventsLocations(str, Enum):
     TH_RESCUED_ALL_CARPENTERS = "TH Rescued All Carpenters"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     TH_1_TORCH_CELL_CARPENTER_FREED = "TH 1 Torch Cell Carpenter Freed"
     TH_DOUBLE_CELL_CARPENTER_FREED = "TH Double Cell Carpenter Freed"
     TH_DEAD_END_CELL_CARPENTER_FREED = "TH Dead End Cell Carpenter Freed"

--- a/worlds/oot_soh/location_access/overworld/zoras_domain.py
+++ b/worlds/oot_soh/location_access/overworld/zoras_domain.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     ZD_GOSSIP_STONE_SONG_FAIRY = "ZD Gossip Stone Song Fairy"
     ZD_NUT_POT = "ZD Nut Pot"
     ZD_STICK_POT = "ZD Stick Pot"
@@ -14,7 +14,7 @@ class EventLocations(str, Enum):
     ZD_FAIRY_GROTTO_FAIRY = "ZD Fairy Grotto Fairy"
 
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     KING_ZORA_THAWED = "King Zora Thawed"
 
 

--- a/worlds/oot_soh/location_access/overworld/zoras_fountain.py
+++ b/worlds/oot_soh/location_access/overworld/zoras_fountain.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     ZF_GOSSIP_STONE_SONG_FAIRY = "ZF Gossip Stone Song Fairy"
     ZF_BUTTERFLY_FAIRY = "ZF Butterfly Fairy"
 

--- a/worlds/oot_soh/location_access/overworld/zoras_river.py
+++ b/worlds/oot_soh/location_access/overworld/zoras_river.py
@@ -3,7 +3,7 @@ from ...LogicHelpers import *
 if TYPE_CHECKING:
     from ... import SohWorld
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     ZR_BUG_GRASS = "ZR Bug Grass"
     MAGIC_BEAN_SALESMAN_SHOP = "Magic Bean Salesman Shop"
     ZR_OPEN_GROTTO_GOSSIP_STONE_SONG_FAIRY = "ZR Upper Grotto Gossip Stone Song Fairy"
@@ -12,7 +12,7 @@ class EventLocations(str, Enum):
     ZR_OPEN_GROTTO_POND_FISH = "ZR Upper Grotto Pond Fish"
     ZR_BEAN_PATCH = "ZR Bean Patch"
 
-class LocalEvents(str, Enum):
+class LocalEvents(StrEnum):
     ZR_BEAN_PLANTED = "ZR Bean Planted"
 
 

--- a/worlds/oot_soh/location_access/root.py
+++ b/worlds/oot_soh/location_access/root.py
@@ -4,7 +4,7 @@ if TYPE_CHECKING:
     from .. import SohWorld
 
 
-class EventLocations(str, Enum):
+class EventLocations(StrEnum):
     ROOT_AMMO_DROP = "Root Ammo Drop"
     ROOT_DEKU_SHIELD = "Root Deku Shield"
     ROOT_HYLIAN_SHIELD = "Root Hylian Shield"


### PR DESCRIPTION
AP has dropped 3.10, so now we can use StrEnum.
So now all instances of `str, Enum` have swapped to `StrEnum` and a whole ton of `.value` was removed since they are no longer needed