### PR TITLE
Make Jabu Jabus Belly Boss Exit accessible

### DIFF
--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -328,7 +328,7 @@ class Regions(StrEnum):
     # JABU_JABUS_BELLY_MQ_PAST_OCTO = "Jabu Jabus Belly MQ Past Octo"
     # JABU_JABUS_BELLY_MQ_BOSS_REGION = "Jabu Jabus Belly MQ Boss Region"
     JABU_JABUS_BELLY_BOSS_ENTRYWAY = "Jabu Jabus Belly Boss Entryway"
-    JABU_JABUS_BELLY_BOSS_EXIT = "Jabu Jabus Belly Boss Exit"
+    # JABU_JABUS_BELLY_BOSS_EXIT = "Jabu Jabus Belly Boss Exit"  # readd for MQ stuff
     JABU_JABUS_BELLY_BOSS_ROOM = "Jabu Jabus Belly Boss Room"
     FOREST_TEMPLE_FIRST_ROOM = "Forest Temple First Room"
     FOREST_TEMPLE_SOUTH_CORRIDOR = "Forest Temple South Corridor"

--- a/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
+++ b/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
@@ -290,7 +290,7 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Connections
     connect_regions(Regions.JABU_JABUS_BELLY_BOSS_ROOM, world, [
-        (Regions.JABU_JABUS_BELLY_BOSS_EXIT, lambda bundle: False),
+        (Regions.JABU_JABUS_BELLY_BOSS_EXIT, lambda bundle: True),
         (Regions.ZORAS_FOUNTAIN, lambda bundle: has_item(
             Events.JABU_JABUS_BELLY_COMPLETED, bundle))
     ])

--- a/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
+++ b/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
@@ -256,12 +256,12 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.JABU_JABUS_BELLY_BOSS_ROOM, lambda bundle: True)
     ])
 
-    # Jabu Jabu's Belly Boss Exit
-    # Connections
-    connect_regions(Regions.JABU_JABUS_BELLY_BOSS_EXIT, world, [
-        (Regions.JABU_JABUS_BELLY_NEAR_BOSS_ROOM, lambda bundle: True)
-        # skipping mq connection
-    ])
+    # # Jabu Jabu's Belly Boss Exit
+    # # Connections
+    # connect_regions(Regions.JABU_JABUS_BELLY_BOSS_EXIT, world, [
+    #     (Regions.JABU_JABUS_BELLY_NEAR_BOSS_ROOM, lambda bundle: True)
+    #     # skipping mq connection
+    # ])
 
     # Jabu Jabu's Belly Boss Room
     # Events
@@ -290,7 +290,7 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Connections
     connect_regions(Regions.JABU_JABUS_BELLY_BOSS_ROOM, world, [
-        (Regions.JABU_JABUS_BELLY_BOSS_EXIT, lambda bundle: True),
+        # (Regions.JABU_JABUS_BELLY_BOSS_EXIT, lambda bundle: False),  # readd for MQ stuff
         (Regions.ZORAS_FOUNTAIN, lambda bundle: has_item(
             Events.JABU_JABUS_BELLY_COMPLETED, bundle))
     ])


### PR DESCRIPTION
Currently, it's completely inaccessible since the only way there has a False rule, and we can't have regions that are not in logic. The region doesn't really matter much, so the options are to set it to True or to delete it. I figure setting it to True is preferable here.