### PR TITLE
Move restrictive fills etc to pre-fill again

### DIFF
--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -277,6 +277,8 @@ def get_open_location_count(world: "SohWorld") -> int:
     if world.options.shuffle_shops:
         open_location_count -= (64 -
                                 (8 * world.options.shuffle_shops_item_amount))
+    else:
+        open_location_count -= 64
     # Subtract dungeon rewards when set to dungeons as they're prefilled later.
     if world.options.shuffle_dungeon_rewards == "dungeons":
         open_location_count -= 9

--- a/worlds/oot_soh/ItemPool.py
+++ b/worlds/oot_soh/ItemPool.py
@@ -232,11 +232,8 @@ def create_item_pool(world: "SohWorld") -> None:
 
 
 def create_triforce_pieces(world: "SohWorld") -> None:
-    filler_item_count = (len(world.multiworld.get_unfilled_locations(world.player))
-                         - len(world.item_pool))
-
     total_triforce_pieces: int = min(
-        filler_item_count, world.options.triforce_hunt_pieces_total.value)
+        get_open_location_count(world), world.options.triforce_hunt_pieces_total.value)
 
     triforce_pieces_made = [world.create_item(
         Items.TRIFORCE_PIECE) for _ in range(total_triforce_pieces)]
@@ -251,8 +248,7 @@ def create_triforce_pieces(world: "SohWorld") -> None:
 
 
 def create_filler_item_pool(world: "SohWorld") -> None:
-    filler_item_count = len(world.multiworld.get_unfilled_locations(
-        world.player)) - len(world.item_pool)
+    filler_item_count = get_open_location_count(world)
 
     # Ice Trap Count
     ice_trap_count = min(filler_item_count, world.options.ice_trap_count.value)
@@ -272,6 +268,19 @@ def create_filler_item_pool(world: "SohWorld") -> None:
     # Add junk items to fill remaining locations
     world.multiworld.itempool += [world.create_item(
         get_filler_item(world)) for _ in range(filler_item_count)]
+
+
+def get_open_location_count(world: "SohWorld") -> int:
+    open_location_count = len(world.multiworld.get_unfilled_locations(
+        world.player)) - len(world.item_pool)
+    # Subtract vanilla shop items because they're prefilled later.
+    if world.options.shuffle_shops:
+        open_location_count -= (64 -
+                                (8 * world.options.shuffle_shops_item_amount))
+    # Subtract dungeon rewards when set to dungeons as they're prefilled later.
+    if world.options.shuffle_dungeon_rewards == "dungeons":
+        open_location_count -= 9
+    return open_location_count
 
 
 def get_filler_item(world: "SohWorld") -> str:

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -106,6 +106,11 @@ class SohWorld(World):
 
         create_item_pool(self)
 
+        if self.options.triforce_hunt:
+            create_triforce_pieces(self)
+
+        create_filler_item_pool(self)
+
     def set_rules(self) -> None:
         # Completion condition.
         self.multiworld.completion_condition[self.player] = lambda state: state.has(
@@ -148,11 +153,6 @@ class SohWorld(World):
 
         fill_shop_items(self)
         set_price_rules(self)
-
-        if self.options.triforce_hunt:
-            create_triforce_pieces(self)
-
-        create_filler_item_pool(self)
 
     def generate_output(self, output_directory: str):
         visualize_regions(self.multiworld.get_region(self.origin_region_name, self.player), f"SOH-Player{self.player}.puml",

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -1,7 +1,7 @@
 import orjson
 import pkgutil
 
-from typing import Any
+from typing import Any, List
 
 from BaseClasses import CollectionState, Item, Tutorial
 from Utils import visualize_regions
@@ -64,6 +64,10 @@ class SohWorld(World):
         # The version is stored on Worlds, so when we're ready to bump our min AP version to 0.6.4, we can use this directly in our slot data:
         # slot_data["apworld_version"] = self.world_version
 
+    def create_item(self, name: str) -> SohItem:
+        item_entry = Items(name)
+        return SohItem(name, item_data_table[item_entry].classification, item_data_table[item_entry].item_id, self.player)
+
     def generate_early(self) -> None:
         # If door of time is set to closed and dungeon rewards aren't shuffled, force child spawn
         if self.options.door_of_time.value == 0 and self.options.shuffle_dungeon_rewards.value == 0:
@@ -76,9 +80,14 @@ class SohWorld(World):
         if self.options.shuffle_scrubs_minimum_price.value > self.options.shuffle_scrubs_maximum_price.value:
             self.options.shuffle_scrubs_maximum_price.value = self.options.shuffle_scrubs_minimum_price.value
 
-    def create_item(self, name: str) -> SohItem:
-        item_entry = Items(name)
-        return SohItem(name, item_data_table[item_entry].classification, item_data_table[item_entry].item_id, self.player)
+    def create_regions(self) -> None:
+        create_regions_and_locations(self)
+        place_locked_items(self)
+        generate_scrub_prices(self)
+        for location in self.get_locations():
+            location.name = str(location.name)
+        for region in self.get_regions():
+            region.name = str(region.name)
 
     def create_items(self) -> None:
         # these are for making the progressive items collect/remove work properly
@@ -96,6 +105,16 @@ class SohWorld(World):
             self.push_precollected(self.create_item(Items.CHILD_WALLET))
 
         create_item_pool(self)
+
+    def set_rules(self) -> None:
+        # Completion condition.
+        self.multiworld.completion_condition[self.player] = lambda state: state.has(
+            Events.GAME_COMPLETED.value, self.player)
+
+    def get_pre_fill_items(self) -> List["Item"]:
+        dungeon_reward_items = [self.create_item(
+            item.value) for item in dungeon_reward_item_mapping.values()]
+        return dungeon_reward_items
 
     def pre_fill(self):
         # Prefill Dungeon Rewards. Need to collect the item pool and vanilla shop items before doing so.
@@ -119,25 +138,18 @@ class SohWorld(World):
                              dungeon_reward_items, single_player_placement=True, lock=True)
 
         fill_shop_items(self)
-        generate_scrub_prices(self)
         set_price_rules(self)
+
         if self.options.triforce_hunt:
             create_triforce_pieces(self)
 
         create_filler_item_pool(self)
 
-    def create_regions(self) -> None:
-        create_regions_and_locations(self)
-        place_locked_items(self)
-        for location in self.get_locations():
-            location.name = str(location.name)
-        for region in self.get_regions():
-            region.name = str(region.name)
-
-    def set_rules(self) -> None:
-        # Completion condition.
-        self.multiworld.completion_condition[self.player] = lambda state: state.has(
-            Events.GAME_COMPLETED.value, self.player)
+    def generate_output(self, output_directory: str):
+        visualize_regions(self.multiworld.get_region(self.origin_region_name, self.player), f"SOH-Player{self.player}.puml",
+                          show_entrance_names=True,
+                          regions_to_highlight=self.multiworld.get_all_state().reachable_regions[
+            self.player])
 
     def fill_slot_data(self) -> dict[str, Any]:
         return {
@@ -249,10 +261,3 @@ class SohWorld(World):
                     state.prog_items[self.player][non_prog_version] = 0
 
         return changed
-
-    def generate_output(self, output_directory: str):
-
-        visualize_regions(self.multiworld.get_region(self.origin_region_name, self.player), f"SOH-Player{self.player}.puml",
-                          show_entrance_names=True,
-                          regions_to_highlight=self.multiworld.get_all_state().reachable_regions[
-            self.player])

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -105,6 +105,7 @@ class SohWorld(World):
 
         create_item_pool(self)
 
+    def pre_fill(self):
         # Prefill Dungeon Rewards. Need to collect the item pool and vanilla shop items before doing so.
         if self.options.shuffle_dungeon_rewards == "dungeons":
             # Create a filled copy of the state so the multiworld can place the dungeon rewards using logic

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -112,9 +112,18 @@ class SohWorld(World):
             Events.GAME_COMPLETED.value, self.player)
 
     def get_pre_fill_items(self) -> List["Item"]:
-        dungeon_reward_items = [self.create_item(
-            item.value) for item in dungeon_reward_item_mapping.values()]
-        return dungeon_reward_items
+        pre_fill_items = []
+
+        if self.options.shuffle_dungeon_rewards == "dungeons":
+            dungeon_reward_items = [self.create_item(
+                item.value) for item in dungeon_reward_item_mapping.values()]
+            pre_fill_items.extend(dungeon_reward_items)
+
+        for region, shop in all_shop_locations:
+            for slot, item in shop.items():
+                pre_fill_items.append(self.create_item(item))
+
+        return pre_fill_items
 
     def pre_fill(self):
         # Prefill Dungeon Rewards. Need to collect the item pool and vanilla shop items before doing so.


### PR DESCRIPTION
Our generation was failing because the restrictive fill for the dungeon rewards was always setting them to the same location for some reason, including placing 2 spirit stones on bongo bongo and twinrova, which in turn would make closed door of time impossible to open as child. As a test, I've moved back those to pre_fill instead of inside create_items. Suddenly the dungeon rewards were placed correctly again, randomly *and* in places child could reach.

I'm just curious if this would still lead to green checks. Scipio has said this isn't something we can do because it can break other worlds, but maybe this can atleast hint to the underlaying problem and lead to a proper solution.