### PR TITLE
Fix can_play_song, clean up item_group_count

### DIFF
--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -910,12 +910,7 @@ def can_detonate_upright_bomb_flower(bundle: tuple[CollectionState, Regions, "So
 def item_group_count(bundle: tuple[CollectionState, Regions, "SohWorld"], item_group: str) -> int:
     state = bundle[0]
     world = bundle[2]
-    items = item_name_groups[item_group]
-    count = 0
-    for item in items:
-        if (state.has(item, world.player)):
-            count += 1
-    return count
+    return state.count_group_unique(item_group, world.player)
 
 
 def ocarina_button_count(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> int:

--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -264,7 +264,7 @@ ocarina_buttons_required: dict[str, list[str]] = {
 def can_play_song(song: StrEnum, bundle: tuple[CollectionState, Regions, "SohWorld"]) -> bool:
     state = bundle[0]
     world = bundle[2]
-    if not has_item(Items.FAIRY_OCARINA, bundle) or not has_item(song, bundle):
+    if not (has_item(Items.FAIRY_OCARINA, bundle) and has_item(song, bundle)):
         return False
     if not world.options.shuffle_ocarina_buttons:
         return True

--- a/worlds/oot_soh/location_access/overworld/temple_of_time.py
+++ b/worlds/oot_soh/location_access/overworld/temple_of_time.py
@@ -51,9 +51,10 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.TEMPLE_OF_TIME, world, [
         (Regions.TOT_ENTRANCE, lambda bundle: True),
         (Regions.BEYOND_DOOR_OF_TIME,
-         lambda bundle: world.options.door_of_time.value == 2 or
-         (can_use(Items.SONG_OF_TIME, bundle) and (world.options.door_of_time.value == 1 or
-                                                   (stone_count(bundle) == 3 and has_item(Items.OCARINA_OF_TIME, bundle))))),
+         lambda bundle: world.options.door_of_time == "open" or
+         (can_use(Items.SONG_OF_TIME, bundle) and
+          (world.options.door_of_time == "song_only" or
+           (stone_count(bundle) == 3 and has_item(Items.OCARINA_OF_TIME, bundle))))),
     ])
 
     # Beyond Door of Time


### PR DESCRIPTION
- For can_play_song, the boolean was a little off
- For item_group_count: there's a helper on state to handle this already, so we should just use that instead of re-implementing it.
- Also made the rule for accessing temple of time use the string option names instead of magic numbers, cause I kept referring back and forth to figure out what was going on and it was annoying

(also this was supposed to be two PRs but I messed up so)