### PR TITLE
Fix #226

### DIFF
--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -1054,17 +1054,3 @@ def is_fire_loop_locked(bundle: tuple[CollectionState, Regions, "SohWorld"]) -> 
 
 def can_ground_jump(bundle: tuple[CollectionState, Regions, "SohWorld"], hasBombFlower: bool = False) -> bool:
     return can_do_trick(Tricks.GROUND_JUMP, bundle) and can_standing_shield(bundle) and (can_use(Items.BOMB_BAG, bundle) or (hasBombFlower and has_item(Items.GORONS_BRACELET, bundle)))
-
-
-def increment_current_count(world: "SohWorld", item: Item, current_count: int) -> int:
-    """
-    If the progressive item count should be increased because of an option (like shuffle_swim), this will increase its current count by 1.
-    Does nothing otherwise.
-    """
-    if ((item.name == Items.PROGRESSIVE_SCALE and not world.options.shuffle_swim)
-            or (item.name == Items.PROGRESSIVE_STICK_CAPACITY and not world.options.shuffle_deku_stick_bag)
-            or (item.name == Items.PROGRESSIVE_NUT_CAPACITY and not world.options.shuffle_deku_nut_bag)
-            or (item.name == Items.PROGRESSIVE_BOMBCHU and not world.options.bombchu_bag)
-            or (item.name == Items.PROGRESSIVE_WALLET and not world.options.shuffle_childs_wallet)):
-        current_count += 1
-    return current_count

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -178,7 +178,15 @@ class SohWorld(World):
         if item.name in progressive_items:
             current_count = state.prog_items[self.player][item.name] + 1
             current_count = increment_current_count(self, item, current_count)
-            for non_prog_version in progressive_items[item.name]:
+            for i, non_prog_version in enumerate(progressive_items[item.name]):
+                # this is a hacky thing to get around weird AP shenanigans with new collection states
+                if (i == 0
+                        and ((item.name == Items.PROGRESSIVE_SCALE and not self.options.shuffle_swim)
+                             or (item.name == Items.PROGRESSIVE_STICK_CAPACITY and not self.options.shuffle_deku_stick_bag)
+                             or (item.name == Items.PROGRESSIVE_NUT_CAPACITY and not self.options.shuffle_deku_nut_bag)
+                             or (item.name == Items.PROGRESSIVE_BOMBCHU and not self.options.bombchu_bag)
+                             or (item.name == Items.PROGRESSIVE_WALLET and not self.options.shuffle_childs_wallet))):
+                    continue
                 state.prog_items[self.player][non_prog_version] = 1
                 current_count -= 1
                 if not current_count:
@@ -195,6 +203,14 @@ class SohWorld(World):
             current_count = state.prog_items[self.player][item.name]
             current_count = increment_current_count(self, item, current_count)
             for i, non_prog_version in enumerate(progressive_items[item.name]):
+                # this is a hacky thing to get around weird AP shenanigans with new collection states
+                if (i == 0
+                        and ((item.name == Items.PROGRESSIVE_SCALE and not self.options.shuffle_swim)
+                             or (item.name == Items.PROGRESSIVE_STICK_CAPACITY and not self.options.shuffle_deku_stick_bag)
+                             or (item.name == Items.PROGRESSIVE_NUT_CAPACITY and not self.options.shuffle_deku_nut_bag)
+                             or (item.name == Items.PROGRESSIVE_BOMBCHU and not self.options.bombchu_bag)
+                             or (item.name == Items.PROGRESSIVE_WALLET and not self.options.shuffle_childs_wallet))):
+                    continue
                 if i + 1 > current_count:
                     state.prog_items[self.player][non_prog_version] = 0
 

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -10,7 +10,7 @@ from .Locations import location_table
 from .Options import SohOptions, soh_option_groups
 from .Regions import create_regions_and_locations, place_locked_items, dungeon_reward_item_mapping
 from .Enums import *
-from .ItemPool import create_item_pool, create_filler_item_pool, create_triforce_pieces
+from .ItemPool import create_item_pool, create_filler_item_pool, create_triforce_pieces, get_filler_item
 from .LogicHelpers import increment_current_count
 from . import RegionAgeAccess
 from .ShopItems import fill_shop_items, generate_scrub_prices, set_price_rules, all_shop_locations
@@ -99,10 +99,14 @@ class SohWorld(World):
         item_entry = Items(name)
         return SohItem(name, item_data_table[item_entry].classification, item_data_table[item_entry].item_id, self.player)
 
+    def get_filler_item_name(self) -> str:
+        return get_filler_item(self)
+
     def create_items(self) -> None:
         # these are for making the progressive items collect/remove work properly
         # when adding another progressive item that is option-dependent like these,
         # be sure to also update LogicHelpers.increment_current_count with it too
+        self.push_precollected(self.create_item(Items.BOTTLE_WITH_MILK))
         if not self.options.shuffle_swim:
             self.push_precollected(self.create_item(Items.BRONZE_SCALE))
         if not self.options.shuffle_deku_stick_bag:

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -106,7 +106,6 @@ class SohWorld(World):
         # these are for making the progressive items collect/remove work properly
         # when adding another progressive item that is option-dependent like these,
         # be sure to also update LogicHelpers.increment_current_count with it too
-        self.push_precollected(self.create_item(Items.BOTTLE_WITH_MILK))
         if not self.options.shuffle_swim:
             self.push_precollected(self.create_item(Items.BRONZE_SCALE))
         if not self.options.shuffle_deku_stick_bag:

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -11,7 +11,6 @@ from .Options import SohOptions, soh_option_groups
 from .Regions import create_regions_and_locations, place_locked_items, dungeon_reward_item_mapping
 from .Enums import *
 from .ItemPool import create_item_pool, create_filler_item_pool, create_triforce_pieces, get_filler_item
-from .LogicHelpers import increment_current_count
 from . import RegionAgeAccess
 from .ShopItems import fill_shop_items, generate_scrub_prices, set_price_rules, all_shop_locations
 from Fill import fill_restrictive
@@ -95,27 +94,26 @@ class SohWorld(World):
         for region in self.get_regions():
             region.name = str(region.name)
 
-    def create_item(self, name: str) -> SohItem:
+    def create_item(self, name: str, create_as_event: bool = False) -> SohItem:
         item_entry = Items(name)
-        return SohItem(name, item_data_table[item_entry].classification, item_data_table[item_entry].item_id, self.player)
+        return SohItem(name, item_data_table[item_entry].classification,
+                       None if create_as_event else item_data_table[item_entry].item_id, self.player)
 
     def get_filler_item_name(self) -> str:
         return get_filler_item(self)
 
     def create_items(self) -> None:
         # these are for making the progressive items collect/remove work properly
-        # when adding another progressive item that is option-dependent like these,
-        # be sure to also update LogicHelpers.increment_current_count with it too
         if not self.options.shuffle_swim:
-            self.push_precollected(self.create_item(Items.BRONZE_SCALE))
+            self.push_precollected(self.create_item(Items.PROGRESSIVE_SCALE, create_as_event=True))
         if not self.options.shuffle_deku_stick_bag:
-            self.push_precollected(self.create_item(Items.DEKU_STICK_BAG))
+            self.push_precollected(self.create_item(Items.PROGRESSIVE_STICK_CAPACITY, create_as_event=True))
         if not self.options.shuffle_deku_nut_bag:
-            self.push_precollected(self.create_item(Items.DEKU_NUT_BAG))
+            self.push_precollected(self.create_item(Items.PROGRESSIVE_NUT_CAPACITY, create_as_event=True))
         if not self.options.bombchu_bag:
-            self.push_precollected(self.create_item(Items.BOMBCHU_BAG))
+            self.push_precollected(self.create_item(Items.PROGRESSIVE_BOMBCHU, create_as_event=True))
         if not self.options.shuffle_childs_wallet:
-            self.push_precollected(self.create_item(Items.CHILD_WALLET))
+            self.push_precollected(self.create_item(Items.PROGRESSIVE_WALLET, create_as_event=True))
 
         create_item_pool(self)
 
@@ -173,26 +171,18 @@ class SohWorld(World):
         set_price_rules(self)
 
     def collect(self, state: CollectionState, item: Item) -> bool:
+        changed = super().collect(state, item)
         state._soh_stale[self.player] = True  # type: ignore
 
         if item.name in progressive_items:
-            current_count = state.prog_items[self.player][item.name] + 1
-            current_count = increment_current_count(self, item, current_count)
-            for i, non_prog_version in enumerate(progressive_items[item.name]):
-                # this is a hacky thing to get around weird AP shenanigans with new collection states
-                if (i == 0
-                        and ((item.name == Items.PROGRESSIVE_SCALE and not self.options.shuffle_swim)
-                             or (item.name == Items.PROGRESSIVE_STICK_CAPACITY and not self.options.shuffle_deku_stick_bag)
-                             or (item.name == Items.PROGRESSIVE_NUT_CAPACITY and not self.options.shuffle_deku_nut_bag)
-                             or (item.name == Items.PROGRESSIVE_BOMBCHU and not self.options.bombchu_bag)
-                             or (item.name == Items.PROGRESSIVE_WALLET and not self.options.shuffle_childs_wallet))):
-                    continue
+            current_count = state.prog_items[self.player][item.name]
+            for non_prog_version in progressive_items[item.name]:
                 state.prog_items[self.player][non_prog_version] = 1
                 current_count -= 1
                 if not current_count:
                     break
 
-        return super().collect(state, item)
+        return changed
 
     def remove(self, state: CollectionState, item: Item) -> bool:
         changed = super().remove(state, item)
@@ -201,16 +191,7 @@ class SohWorld(World):
 
         if item.name in progressive_items:
             current_count = state.prog_items[self.player][item.name]
-            current_count = increment_current_count(self, item, current_count)
             for i, non_prog_version in enumerate(progressive_items[item.name]):
-                # this is a hacky thing to get around weird AP shenanigans with new collection states
-                if (i == 0
-                        and ((item.name == Items.PROGRESSIVE_SCALE and not self.options.shuffle_swim)
-                             or (item.name == Items.PROGRESSIVE_STICK_CAPACITY and not self.options.shuffle_deku_stick_bag)
-                             or (item.name == Items.PROGRESSIVE_NUT_CAPACITY and not self.options.shuffle_deku_nut_bag)
-                             or (item.name == Items.PROGRESSIVE_BOMBCHU and not self.options.bombchu_bag)
-                             or (item.name == Items.PROGRESSIVE_WALLET and not self.options.shuffle_childs_wallet))):
-                    continue
                 if i + 1 > current_count:
                     state.prog_items[self.player][non_prog_version] = 0
 


### PR DESCRIPTION
Fixes https://github.com/aMannus/Archipelago/issues/226

The issue was that during playthrough calculation, the `multiworld.state` culls items until it gets to a "minimal" state in which it can beat the game. After that process, it builds spheres, but during that it does `state = CollectionState(multiworld)`, creating a new state. This new state has never run collect or remove on wallets, and does not have the precollected Child Wallet since it was removed during the culling. So, it fails because it doesn't have the Child Wallet that the `multiworld.state` does have.

The only real solution here is to precollect event versions of the progressive items. This means they'll show up in sphere 0, which is eh. If you can live with it, then this is the best solution. If not, rip progressive items system and significant gen time speedup.



Oh also actually put get_filler_item_name in the world class so it works better with start_inventory_from_pool, plando from_pool, and anything else that uses it