### PR TITLE
Fix shop item price rules

### DIFF
--- a/worlds/oot_soh/ShopItems.py
+++ b/worlds/oot_soh/ShopItems.py
@@ -235,7 +235,6 @@ def generate_scrub_prices(world: "SohWorld") -> None:
 
 
 def create_random_price(min_price: int, max_price: int, world: "SohWorld") -> int:
-    price = 0
     # randrange needs an actual range to work, so just pick the price directly if min/max are the same.
     if min_price == max_price:
         price = min_price
@@ -251,7 +250,7 @@ def set_price_rules(world: "SohWorld") -> None:
     for region, shop in all_shop_locations:
         for slot in shop.keys():
             price = world.shop_prices[slot]
-            def price_rule(bundle): return can_afford(price, bundle)
+            def price_rule(bundle, p=price): return can_afford(p, bundle)
             location = world.get_location(slot)
             add_rule(location, rule_wrapper.wrap(region, price_rule, world))
 
@@ -259,7 +258,7 @@ def set_price_rules(world: "SohWorld") -> None:
     if world.options.shuffle_scrubs:
         for slot in scrubs_location_table.keys():
             price = world.scrub_prices[slot]
-            def price_rule(bundle): return can_afford(price, bundle)
+            def price_rule(bundle, p=price): return can_afford(p, bundle)
             location = world.get_location(slot)
             # Parent region shouldn't matter at all here, so just add ROOT so we don't have to make a list of all scrubs and their regions.
             add_rule(location, rule_wrapper.wrap(

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -129,6 +129,12 @@ class SohWorld(World):
         self.multiworld.completion_condition[self.player] = lambda state: state.has(
             Events.GAME_COMPLETED.value, self.player)
 
+        # UT doesn't run pre_fill, so we're doing this here instead
+        if self.using_ut:
+            self.shop_prices = self.passthrough["shop_prices"]
+            self.shop_vanilla_items = self.passthrough["shop_vanilla_items"]
+            set_price_rules(self)
+
     def get_pre_fill_items(self) -> List["Item"]:
         pre_fill_items = []
 
@@ -167,9 +173,9 @@ class SohWorld(World):
 
         fill_shop_items(self)
 
+        # if UT ever does start running pre_fill, this will stop it from overwriting the shop price rules
         if self.using_ut:
-            self.shop_prices = self.passthrough["shop_prices"]
-            self.shop_vanilla_items = self.passthrough["shop_vanilla_items"]
+            return
 
         set_price_rules(self)
 


### PR DESCRIPTION
The name of the game today is lambda capture!

Lambda capture (or in this case function capture, it just usually happens with lambdas) is when you have a loop, and during that loop you make a function with a variable in it. That variable gets updated every loop, so the reference to it in the function _also_ gets updated.

Example from qwint:
```py
>>> x = []
>>> for i in range(5):
...     def foo(): return i
...     x.append(foo)
...
>>> for n in x:
...     print(f"{n}: {n()}")
...
<function foo at 0x000002229ECA99E0>: 4
<function foo at 0x000002229ECA9B20>: 4
<function foo at 0x000002229ECA9BC0>: 4
<function foo at 0x000002229ECA9C60>: 4
<function foo at 0x000002229ECA9DA0>: 4
```


So, the fix is to assign the price in the function to something, that way the other value _isn't_ updating every loop.

Also UT doesn't run pre_fill so I moved the spot where UT updates shop prices to pre_fill. Because of the way SoH is set up, every location gets made without rules, and then rules are (expected to be) added after. So a location that isn't getting its rules added shows up sphere 1. If this fix was in place but not the lambda capture issue, all shop items would show up as in logic as soon as you get enough money to purchase Shop Item 8 in Zora's Domain.