### PR TITLE
Add location_name_groups

### DIFF
--- a/worlds/oot_soh/Locations.py
+++ b/worlds/oot_soh/Locations.py
@@ -2581,3 +2581,11 @@ location_data_table: dict[str, int] = {
 
 location_table = {name: address for name,
                   address in location_data_table.items()}
+
+
+# For making priority locations or excluded locations easier
+# contributions to add more location groups are welcome
+location_name_groups: dict[str, set[str]] = {
+    "Bosses": {Locations.QUEEN_GOHMA, Locations.KING_DODONGO, Locations.BARINADE, Locations.PHANTOM_GANON, 
+               Locations.VOLVAGIA, Locations.MORPHA, Locations.BONGO_BONGO, Locations.TWINROVA, Locations.GANON},
+}

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -6,7 +6,7 @@ from typing import Any, List
 from BaseClasses import CollectionState, Item, Tutorial
 from worlds.AutoWorld import WebWorld, World
 from .Items import SohItem, item_data_table, item_table, item_name_groups, progressive_items
-from .Locations import location_table
+from .Locations import location_table, location_name_groups
 from .Options import SohOptions, soh_option_groups
 from .Regions import create_regions_and_locations, place_locked_items, dungeon_reward_item_mapping
 from .Enums import *
@@ -49,6 +49,7 @@ class SohWorld(World):
     location_name_to_id = location_table
     item_name_to_id = item_table
     item_name_groups = item_name_groups
+    location_name_groups = location_name_groups
 
     # Universal Tracker stuff, does not do anything in normal gen
     using_ut: bool  # so we can check if we're using UT only once


### PR DESCRIPTION
Add location_name_groups, make one group as more of an example.
`location_name_groups` are mainly useful for setting up priority/excluded locations in a yaml.
I _think_ plando can use it too? Not sure.