### PR TITLE
Entrance Shuffle

### DIFF
--- a/worlds/oot_soh/EntranceShuffle.py
+++ b/worlds/oot_soh/EntranceShuffle.py
@@ -1,8 +1,13 @@
-from .Enums import SOHBossEntranceExitNames, SOHBossEntranceNames  # , Ages, Regions
+from typing import TYPE_CHECKING, Callable
+from .Enums import SOHBossEntranceExitNames, SOHBossEntranceNames, SOHDungeonExitNames, SOHDungeonEntranceNames  # , Ages, Regions
+from entrance_rando import disconnect_entrance_for_randomization, randomize_entrances
 # from entrance_rando import ERPlacementState, Entrance
 # from . import RegionAgeAccess
 
-# Pretty sure this is only needed for One Way entrances
+if TYPE_CHECKING:
+    from . import SohWorld
+
+# This is only needed for One Way entrances
 entrance_matching = {
     SOHBossEntranceNames.DEKU_TREE_BOSS_ENTRANCE: SOHBossEntranceExitNames.DEKU_TREE_BOSS_EXIT,
     SOHBossEntranceNames.DODONGOS_CAVERN_BOSS_ENTRANCE: SOHBossEntranceExitNames.DODONGOS_CAVERN_BOSS_EXIT,
@@ -15,45 +20,11 @@ entrance_matching = {
 }
 
 
-# special_entrance_requirements = {
-#     SOHBossEntranceExitNames.JABU_JABUS_BOSS_EXIT.value: Ages.CHILD,
-#     SOHBossEntranceExitNames.WATER_TEMPLE_BOSS_EXIT.value: Ages.ADULT
-# }
+# Might need to return the ER Placement state at the end
+def randomize_entrances_soh(world: "SohWorld", entrances_to_shuffle: set[SOHBossEntranceNames | SOHDungeonEntranceNames | SOHDungeonExitNames], entrance_groups: dict[int: list[int]]) -> None:
+    for entranceEnum in entrances_to_shuffle:
+        disconnect_entrance_for_randomization(world.multiworld.get_entrance(
+            entranceEnum.value, world.player), one_way_target_name=entrance_matching[entranceEnum].value if entranceEnum in entrance_matching else None)
 
-# Couldn't get this to work. I instead opted for more groups that intermingle. I feel like this could work though.
-# Two issues:
-# 1. At this point no items have been collected so our age logic always returns false.
-# 2. I was having a hard time
-# def soh_oot_on_connect(er_state: ERPlacementState, placed_exits: list[Entrance], paired_entrances: list[Entrance]) -> bool:
-
-#     updated: bool = False
-#     index: int = 0
-#     regions_dict = {i.value: i for i in Regions}
-
-#     for _ in paired_entrances:
-#         print(
-#             f"Entrance:{paired_entrances[index].name} | Exit Region: {placed_exits[index].connected_region.name}")
-#         if paired_entrances[index].name in special_entrance_requirements:
-
-#             if er_state.collection_state._soh_can_reach_as_age(regions_dict.get(placed_exits[index].connected_region.name), special_entrance_requirements[paired_entrances[index].name], er_state.world.player):
-#                 index += 1
-#                 continue
-
-#             # pick another random exit and see if this age can reach it
-#             exits = [er_state.entrance_lookup.find_target(
-#                 exit.value) for exit in SOHBossEntranceExitNames]
-#             er_state.world.random.shuffle(exits)
-#             picked_exit = None
-
-#             for exit in exits:
-#                 if er_state.collection_state._soh_can_reach_as_age(regions_dict.get(exit.connected_region.name), special_entrance_requirements[paired_entrances[index].name], er_state.world.player):
-#                     picked_exit = exit
-#                     break
-
-#             er_state.connect(picked_exit, paired_entrances[index])
-#             if not updated:
-#                 updated = True
-
-#         index += 1
-
-#     return updated
+    randomize_entrances(
+        world, (not bool(world.options.decouple_entrances)), entrance_groups, True)

--- a/worlds/oot_soh/EntranceShuffle.py
+++ b/worlds/oot_soh/EntranceShuffle.py
@@ -1,0 +1,59 @@
+from .Enums import SOHBossEntranceExitNames, SOHBossEntranceNames  # , Ages, Regions
+# from entrance_rando import ERPlacementState, Entrance
+# from . import RegionAgeAccess
+
+# Pretty sure this is only needed for One Way entrances
+entrance_matching = {
+    SOHBossEntranceNames.DEKU_TREE_BOSS_ENTRANCE: SOHBossEntranceExitNames.DEKU_TREE_BOSS_EXIT,
+    SOHBossEntranceNames.DODONGOS_CAVERN_BOSS_ENTRANCE: SOHBossEntranceExitNames.DODONGOS_CAVERN_BOSS_EXIT,
+    SOHBossEntranceNames.JABU_JABUS_BOSS_ENTRANCE: SOHBossEntranceExitNames.JABU_JABUS_BOSS_EXIT,
+    SOHBossEntranceNames.FOREST_TEMPLE_BOSS_ENTRANCE: SOHBossEntranceExitNames.FOREST_TEMPLE_BOSS_EXIT,
+    SOHBossEntranceNames.FIRE_TEMPLE_BOSS_ENTRANCE: SOHBossEntranceExitNames.FIRE_TEMPLE_BOSS_EXIT,
+    SOHBossEntranceNames.WATER_TEMPLE_BOSS_ENTRANCE: SOHBossEntranceExitNames.WATER_TEMPLE_BOSS_EXIT,
+    SOHBossEntranceNames.SHADOW_TEMPLE_BOSS_ENTRANCE: SOHBossEntranceExitNames.SHADOW_TEMPLE_BOSS_EXIT,
+    SOHBossEntranceNames.SPIRIT_TEMPLE_BOSS_ENTRANCE: SOHBossEntranceExitNames.SPIRIT_TEMPLE_BOSS_EXIT,
+}
+
+
+# special_entrance_requirements = {
+#     SOHBossEntranceExitNames.JABU_JABUS_BOSS_EXIT.value: Ages.CHILD,
+#     SOHBossEntranceExitNames.WATER_TEMPLE_BOSS_EXIT.value: Ages.ADULT
+# }
+
+# Couldn't get this to work. I instead opted for more groups that intermingle. I feel like this could work though.
+# Two issues:
+# 1. At this point no items have been collected so our age logic always returns false.
+# 2. I was having a hard time
+# def soh_oot_on_connect(er_state: ERPlacementState, placed_exits: list[Entrance], paired_entrances: list[Entrance]) -> bool:
+
+#     updated: bool = False
+#     index: int = 0
+#     regions_dict = {i.value: i for i in Regions}
+
+#     for _ in paired_entrances:
+#         print(
+#             f"Entrance:{paired_entrances[index].name} | Exit Region: {placed_exits[index].connected_region.name}")
+#         if paired_entrances[index].name in special_entrance_requirements:
+
+#             if er_state.collection_state._soh_can_reach_as_age(regions_dict.get(placed_exits[index].connected_region.name), special_entrance_requirements[paired_entrances[index].name], er_state.world.player):
+#                 index += 1
+#                 continue
+
+#             # pick another random exit and see if this age can reach it
+#             exits = [er_state.entrance_lookup.find_target(
+#                 exit.value) for exit in SOHBossEntranceExitNames]
+#             er_state.world.random.shuffle(exits)
+#             picked_exit = None
+
+#             for exit in exits:
+#                 if er_state.collection_state._soh_can_reach_as_age(regions_dict.get(exit.connected_region.name), special_entrance_requirements[paired_entrances[index].name], er_state.world.player):
+#                     picked_exit = exit
+#                     break
+
+#             er_state.connect(picked_exit, paired_entrances[index])
+#             if not updated:
+#                 updated = True
+
+#         index += 1
+
+#     return updated

--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -69,7 +69,7 @@ class Regions(StrEnum):
     GF_NEAR_GROTTO = "GF Near Grotto"
     GF_OUTSIDE_GTG = "GF Outside GTG"
     GF_TO_GTG = "GF to GTG"
-    GF_EXITING_GTG = "GF Exiting GTG"
+    # GF_EXITING_GTG = "GF Exiting GTG"
     GF_ABOVE_GTG = "GF Above GTG"
     GF_BOTTOM_OF_LOWER_VINES = "GF Bottom of Lower Vines"
     GF_TOP_OF_LOWER_VINES = "GF Top of Lower Vines"
@@ -103,7 +103,7 @@ class Regions(StrEnum):
     WASTELAND_NEAR_COLOSSUS = "Wasteland Near Colossus"
     DESERT_COLOSSUS = "Desert Colossus"
     DESERT_COLOSSUS_OASIS = "Desert Colossus Oasis"
-    DESERT_COLOSSUS_OUTSIDE_TEMPLE = "Desert Colossus Outside Temple"
+    # DESERT_COLOSSUS_OUTSIDE_TEMPLE = "Desert Colossus Outside Temple"
     COLOSSUS_GREAT_FAIRY_FOUNTAIN = "Colossus Great Fairy Fountain"
     COLOSSUS_GROTTO = "Colossus Grotto"
     MARKET_ENTRANCE = "Market Entrance"
@@ -124,7 +124,7 @@ class Regions(StrEnum):
     BEYOND_DOOR_OF_TIME = "Beyond Door of Time"
     MASTER_SWORD_PEDESTAL = "Master Sword Pedestal"
     CASTLE_GROUNDS = "Castle Grounds"
-    CASTLE_GROUNDS_FROM_GANONS_CASTLE = "Castle Grounds From Ganon's Castle"
+    # CASTLE_GROUNDS_FROM_GANONS_CASTLE = "Castle Grounds From Ganon's Castle"
     HYRULE_CASTLE_GROUNDS = "Hyrule Castle Grounds"
     HC_GARDEN_SONG_FROM_IMPA = "HC Garden Song From Impa"
     HC_GARDEN = "HC Garden"
@@ -3836,29 +3836,24 @@ class Tricks(StrEnum):
     GANONS_CASTLE_GOLD_GAUNTLET_SKIP = "Ganons Castle Gold Gauntlet Skip"
 
 
+# Probabaly need more than these for other shuffles, but for now this works.
 class SOHEntranceGroups(IntEnum):
     OTHER = 0
-    DUNGEONS = 1
-    CHILD_BOSSES = 2
-    CHILD_ONLY_BOSSES = 3
-    ADULT_BOSSES = 4
-    ADULT_ONLY_BOSSES = 5
-    OVERWORLD = 6
-    INTERIOR = 7
+    CHILD_DUNGEONS = 1
+    CHILD_ONLY_DUNGEONS = 2
+    ADULT_DUNGEONS = 3
+    ADULT_ONLY_DUNGEONS = 4
+    BOTH_DUNGEONS = 5
+    CHILD_BOSSES = 6
+    CHILD_ONLY_BOSSES = 7
+    ADULT_BOSSES = 8
+    ADULT_ONLY_BOSSES = 9
+    EITHER_BOSSES = 10
+    OVERWORLD = 11
+    INTERIOR = 12
 
 
-class SOHDungeonEntranceName(StrEnum):
-    DEKU_TREE_DUNGEON_ENTRANCE = "Deku Tree Dungeon Entrance"
-    DODONGOS_CAVERN_DUNGEON_ENTRANCE = "Dodongos Cavern Dungeon Entrance"
-    JABU_JABUS_DUNGEON_ENTRANCE = "Jabu Jabus Dungeon Entrance"
-    FOREST_TEMPLE_DUNGEON_ENTRANCE = "Forest Temple Dungeon Entrance"
-    FIRE_TEMPLE_DUNGEON_ENTRANCE = "Fire Temple Dungeon Entrance"
-    WATER_TEMPLE_DUNGEON_ENTRANCE = "Water Temple Dungeon Entrance"
-    SHADOW_TEMPLE_DUNGEON_ENTRANCE = "Shadow Temple Dungeon Entrance"
-    SPIRIT_TEMPLE_DUNGEON_ENTRANCE = "Spirit Temple Dungeon Entrance"
-
-
-class SOHDungeonEntranceExitNames(StrEnum):
+class SOHDungeonExitNames(StrEnum):
     DEKU_TREE_DUNGEON_EXIT = "Deku Tree Dungeon Exit"
     DODONGOS_CAVERN_DUNGEON_EXIT = "Dodongos Cavern Dungeon Exit"
     JABU_JABUS_DUNGEON_EXIT = "Jabu Jabus Dungeon Exit"
@@ -3867,6 +3862,25 @@ class SOHDungeonEntranceExitNames(StrEnum):
     WATER_TEMPLE_DUNGEON_EXIT = "Water Temple Dungeon Exit"
     SHADOW_TEMPLE_DUNGEON_EXIT = "Shadow Temple Dungeon Exit"
     SPIRIT_TEMPLE_DUNGEON_EXIT = "Spirit Temple Dungeon Exit"
+    GANONS_CASTLE_DUNGEON_EXIT = "Ganons Castle Dungeon Exit"
+    BOTTOM_OF_THE_WELL_DUNGEON_EXIT = "Bottom of the Well Dungeon Exit"
+    ICE_CAVERN_DUNGEON_EXIT = "Ice Cavern Dungeon Exit"
+    GERUDO_TRAINING_GROUND_DUNGEON_EXIT = "Gerudo Training Ground Dungeon Exit"
+
+
+class SOHDungeonEntranceNames(StrEnum):
+    DEKU_TREE_DUNGEON_ENTRANCE = "Deku Tree Dungeon Entrance"
+    DODONGOS_CAVERN_DUNGEON_ENTRANCE = "Dodongos Cavern Dungeon Entrance"
+    JABU_JABUS_DUNGEON_ENTRANCE = "Jabu Jabus Dungeon Entrance"
+    FOREST_TEMPLE_DUNGEON_ENTRANCE = "Forest Temple Dungeon Entrance"
+    FIRE_TEMPLE_DUNGEON_ENTRANCE = "Fire Temple Dungeon Entrance"
+    WATER_TEMPLE_DUNGEON_ENTRANCE = "Water Temple Dungeon Entrance"
+    SHADOW_TEMPLE_DUNGEON_ENTRANCE = "Shadow Temple Dungeon Entrance"
+    SPIRIT_TEMPLE_DUNGEON_ENTRNACE = "Spirit Temple Dungeon Entrance"
+    GANONS_CASTLE_DUNGEON_ENTRANCE = "Ganons Castle Dungeon Entrance"
+    BOTTOM_OF_THE_WELL_DUNGEON_ENTRANCE = "Bottom of the Well Dungeon Entrance"
+    ICE_CAVERN_DUNGEON_ENTRANCE = "Ice Cavern Dungeon Entrance"
+    GERUDO_TRAINING_GROUND_DUNGEON_ENTRANCE = "Gerudo Training Ground Dungeon Entrance"
 
 
 class SOHBossEntranceNames(StrEnum):

--- a/worlds/oot_soh/Enums.py
+++ b/worlds/oot_soh/Enums.py
@@ -3834,3 +3834,58 @@ class Tricks(StrEnum):
     BOTTOM_OF_THE_WELL_SKULL_PUSH = "Bottom of the Well Skull Push"
     GANONS_CASTLE_BARRIER_SKIP_HOVER = "Ganons Castle Barrier Skip Hover"
     GANONS_CASTLE_GOLD_GAUNTLET_SKIP = "Ganons Castle Gold Gauntlet Skip"
+
+
+class SOHEntranceGroups(IntEnum):
+    OTHER = 0
+    DUNGEONS = 1
+    CHILD_BOSSES = 2
+    CHILD_ONLY_BOSSES = 3
+    ADULT_BOSSES = 4
+    ADULT_ONLY_BOSSES = 5
+    OVERWORLD = 6
+    INTERIOR = 7
+
+
+class SOHDungeonEntranceName(StrEnum):
+    DEKU_TREE_DUNGEON_ENTRANCE = "Deku Tree Dungeon Entrance"
+    DODONGOS_CAVERN_DUNGEON_ENTRANCE = "Dodongos Cavern Dungeon Entrance"
+    JABU_JABUS_DUNGEON_ENTRANCE = "Jabu Jabus Dungeon Entrance"
+    FOREST_TEMPLE_DUNGEON_ENTRANCE = "Forest Temple Dungeon Entrance"
+    FIRE_TEMPLE_DUNGEON_ENTRANCE = "Fire Temple Dungeon Entrance"
+    WATER_TEMPLE_DUNGEON_ENTRANCE = "Water Temple Dungeon Entrance"
+    SHADOW_TEMPLE_DUNGEON_ENTRANCE = "Shadow Temple Dungeon Entrance"
+    SPIRIT_TEMPLE_DUNGEON_ENTRANCE = "Spirit Temple Dungeon Entrance"
+
+
+class SOHDungeonEntranceExitNames(StrEnum):
+    DEKU_TREE_DUNGEON_EXIT = "Deku Tree Dungeon Exit"
+    DODONGOS_CAVERN_DUNGEON_EXIT = "Dodongos Cavern Dungeon Exit"
+    JABU_JABUS_DUNGEON_EXIT = "Jabu Jabus Dungeon Exit"
+    FOREST_TEMPLE_DUNGEON_EXIT = "Forest Temple Dungeon Exit"
+    FIRE_TEMPLE_DUNGEON_EXIT = "Fire Temple Dungeon Exit"
+    WATER_TEMPLE_DUNGEON_EXIT = "Water Temple Dungeon Exit"
+    SHADOW_TEMPLE_DUNGEON_EXIT = "Shadow Temple Dungeon Exit"
+    SPIRIT_TEMPLE_DUNGEON_EXIT = "Spirit Temple Dungeon Exit"
+
+
+class SOHBossEntranceNames(StrEnum):
+    DEKU_TREE_BOSS_ENTRANCE = "Deku Tree Boss Entrance"
+    DODONGOS_CAVERN_BOSS_ENTRANCE = "Dodongos Cavern Boss Entrance"
+    JABU_JABUS_BOSS_ENTRANCE = "Jabu Jabus Boss Entrance"
+    FOREST_TEMPLE_BOSS_ENTRANCE = "Forest Temple Boss Entrance"
+    FIRE_TEMPLE_BOSS_ENTRANCE = "Fire Temple Boss Entrance"
+    WATER_TEMPLE_BOSS_ENTRANCE = "Water Temple Boss Entrance"
+    SHADOW_TEMPLE_BOSS_ENTRANCE = "Shadow Temple Boss Entrance"
+    SPIRIT_TEMPLE_BOSS_ENTRANCE = "Spirit Temple Boss Entrance"
+
+
+class SOHBossEntranceExitNames(StrEnum):
+    DEKU_TREE_BOSS_EXIT = "Deku Tree Boss Exit"
+    DODONGOS_CAVERN_BOSS_EXIT = "Dodongos Cavern Boss Exit"
+    JABU_JABUS_BOSS_EXIT = "Jabu Jabus Boss Exit"
+    FOREST_TEMPLE_BOSS_EXIT = "Forest Temple Boss Exit"
+    FIRE_TEMPLE_BOSS_EXIT = "Fire Temple Boss Exit"
+    WATER_TEMPLE_BOSS_EXIT = "Water Temple Boss Exit"
+    SHADOW_TEMPLE_BOSS_EXIT = "Shadow Temple Boss Exit"
+    SPIRIT_TEMPLE_BOSS_EXIT = "Spirit Temple Boss Exit"

--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -44,7 +44,7 @@ def add_locations(parent_region: Regions, world: "SohWorld",
 
 
 def connect_regions(parent_region: Regions, world: "SohWorld",
-                    child_regions: list[tuple[Regions, Callable[[tuple[CollectionState, Regions, "SohWorld"]], bool], SOHBossEntranceNames, SOHEntranceGroups, EntranceType]]) -> None:
+                    child_regions: list[tuple[Regions, Callable[[tuple[CollectionState, Regions, "SohWorld"]], bool], SOHBossEntranceNames | SOHDungeonExitNames, SOHEntranceGroups, EntranceType]]) -> None:
     for region in child_regions:
         regionName = region[0]
         entranceName = None

--- a/worlds/oot_soh/LogicHelpers.py
+++ b/worlds/oot_soh/LogicHelpers.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, Callable
 
-from BaseClasses import CollectionState, ItemClassification as IC, Item
+from BaseClasses import CollectionState, ItemClassification as IC, Item, EntranceType, Group
 from .Locations import SohLocation
 from worlds.generic.Rules import set_rule
 from .Enums import *
@@ -44,14 +44,22 @@ def add_locations(parent_region: Regions, world: "SohWorld",
 
 
 def connect_regions(parent_region: Regions, world: "SohWorld",
-                    child_regions: list[tuple[Regions, Callable[[tuple[CollectionState, Regions, "SohWorld"]], bool]]]) -> None:
+                    child_regions: list[tuple[Regions, Callable[[tuple[CollectionState, Regions, "SohWorld"]], bool], SOHBossEntranceNames, SOHEntranceGroups, EntranceType]]) -> None:
     for region in child_regions:
         regionName = region[0]
+        entranceName = None
         def regionRule(bundle): return True
         if len(region) > 1:
             regionRule = region[1]
-        world.get_region(parent_region).connect(world.get_region(regionName),
-                                                rule=rule_wrapper.wrap(parent_region, regionRule, world))
+        if len(region) > 2:
+            entranceName = region[2].value
+        entrance = world.get_region(parent_region).connect(world.get_region(
+            regionName), entranceName, rule_wrapper.wrap(parent_region, regionRule, world))
+
+        if len(region) > 3:
+            entrance.randomization_group = region[3].value
+        if len(region) > 4:
+            entrance.randomization_type = region[4]
 
 
 def add_events(parent_region: Regions, world: "SohWorld",

--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -864,6 +864,14 @@ class ShuffleDungeonEntrances(Choice):
     default = 0
 
 
+class DecoupleEntrances(Toggle):
+    """
+    Decouple entrances when shuffling them. This means that you are no longer guaranteed to end up back where you came from when you go back through an entrance.
+    This also adds the one way entrance from Gerudo Valley to Lake Hylia in the pool of overworld entrances when they are shuffled.
+    """
+    display_name = "Decouple Entrances"
+
+
 @dataclass
 class SohOptions(PerGameCommonOptions):
     closed_forest: ClosedForest
@@ -949,6 +957,7 @@ class SohOptions(PerGameCommonOptions):
     shuffle_entrances: ShuffleEntrances
     shuffle_dungeon_entrances: ShuffleDungeonEntrances
     shuffle_boss_entrances: ShuffleDungeonBossEntrances
+    decouple_entrances: DecoupleEntrances
 
 
 soh_option_groups = [
@@ -979,14 +988,14 @@ soh_option_groups = [
     OptionGroup("Shuffle Entrances", [
         ShuffleEntrances,
         ShuffleDungeonEntrances,
-        ShuffleDungeonBossEntrances
+        ShuffleDungeonBossEntrances,
+        DecoupleEntrances
         # Overworld Entrances
         # Interior Entrances
         # Grotto Entrances
         # Owl Drops
         # Warp Songs
         # Overworld Spawns
-        # Decouple Entrances
     ]),
     OptionGroup("Shuffle Items", [
         # Shuffle Songs -- idk if this or the other ones here will be an actual option here, delete if not

--- a/worlds/oot_soh/Options.py
+++ b/worlds/oot_soh/Options.py
@@ -827,6 +827,43 @@ class IceTrapFillerReplacement(Range):
     default = 0
 
 
+class ShuffleEntrances(Toggle):
+    """
+    Shuffle Entrances. Enables the use of all the below entrance options.
+    """
+    display_name = "Shuffle Entrances"
+
+
+class ShuffleDungeonBossEntrances(Choice):
+    """
+    Shuffle the pool of dungeon boss entrances. This affects the boss rooms of all stone and medallion dungeons
+    Age Restricted - Shuffle the entrances of child and adult boss rooms separetly.
+    Full - Shuffle the entrances of all boss rooms together. Child may be expected to defeat Phantom Ganon and/or Bongo Bongo
+    """
+    display_name = "Boss Entrances Shuffle"
+    option_off = 0
+    option_age_restricted = 1
+    option_full = 2
+    default = 0
+
+
+class ShuffleDungeonEntrances(Choice):
+    """
+    Shuffle the pool of dungeon entrances, including Bottom of the Well, Ice Cavern and Gerudo Training Ground.
+    Shuffling Ganon's Castle can be enabled separately.
+    Additionally, the entrances of Deku Tree, Fire Temple, Bottom of the Well and Gerudo Training Ground are 
+    opened for both child and adult.
+    - Deku Tree will be open for adult after Mido has seen child Link with a sword and a shield.
+    - Bottom of the Well will be open for adult after playing Song of Storms to the Windmill guy as child.
+    - Gerudo Training Ground will be open for child after adult has paid to open the gate once.
+    """
+    display_name = "Dungeon Entrances Shuffle"
+    option_off = 0
+    option_on = 1
+    option_on_plus_ganon = 2
+    default = 0
+
+
 @dataclass
 class SohOptions(PerGameCommonOptions):
     closed_forest: ClosedForest
@@ -909,6 +946,9 @@ class SohOptions(PerGameCommonOptions):
     shuffle_100_gs_reward: Shuffle100GSReward
     ice_trap_count: IceTrapCount
     ice_trap_filler_replacement: IceTrapFillerReplacement
+    shuffle_entrances: ShuffleEntrances
+    shuffle_dungeon_entrances: ShuffleDungeonEntrances
+    shuffle_boss_entrances: ShuffleDungeonBossEntrances
 
 
 soh_option_groups = [
@@ -936,17 +976,18 @@ soh_option_groups = [
         TriforceHuntPiecesTotal,
         TriforceHuntPiecesRequiredPercentage,
     ]),
-    # OptionGroup("Shuffle Entrances", [
-    #     # Dungeon Entrances
-    #     # Boss Entrances
-    #     # Overworld Entrances
-    #     # Interior Entrances
-    #     # Grotto Entrances
-    #     # Owl Drops
-    #     # Warp Songs
-    #     # Overworld Spawns
-    #     # Decouple Entrances
-    # ]),
+    OptionGroup("Shuffle Entrances", [
+        ShuffleEntrances,
+        ShuffleDungeonEntrances,
+        ShuffleDungeonBossEntrances
+        # Overworld Entrances
+        # Interior Entrances
+        # Grotto Entrances
+        # Owl Drops
+        # Warp Songs
+        # Overworld Spawns
+        # Decouple Entrances
+    ]),
     OptionGroup("Shuffle Items", [
         # Shuffle Songs -- idk if this or the other ones here will be an actual option here, delete if not
         ShuffleTokens,

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -17,7 +17,7 @@ from .ShopItems import fill_shop_items, generate_scrub_prices, set_price_rules, 
 from Fill import fill_restrictive
 from .Presets import oot_soh_options_presets
 from .UniversalTracker import setup_options_from_slot_data
-from .EntranceShuffle import entrance_matching
+from .EntranceShuffle import randomize_entrances_soh
 
 import logging
 logger = logging.getLogger("SOH_OOT")
@@ -88,7 +88,8 @@ class SohWorld(World):
             self.options.shuffle_scrubs_maximum_price.value = self.options.shuffle_scrubs_minimum_price.value
 
         # Entrance Rando stuff
-        self.explicit_indirect_conditions = True
+        if (self.options.shuffle_dungeon_entrances.value > 0 or self.options.shuffle_boss_entrances.value > 0):
+            self.explicit_indirect_conditions = True
 
     def create_regions(self) -> None:
         create_regions_and_locations(self)
@@ -141,38 +142,47 @@ class SohWorld(World):
             set_price_rules(self)
 
     def connect_entrances(self):
-        if self.options.shuffle_entrances.value:
-            entrances_to_shuffle = set()
-            entrance_groups_combined = dict()
+        entrances_to_shuffle = set()
 
-            # Dungeon Entrances
-            if self.options.shuffle_dungeon_entrances.value > 0:
-                for entrance in SOHBossEntranceNames:
+        # Dungeon Entrances
+        if self.options.shuffle_dungeon_entrances.value > 0:
+            for entrance in SOHDungeonExitNames:
+                if entrance != SOHDungeonExitNames.GANONS_CASTLE_DUNGEON_EXIT or self.options.shuffle_dungeon_entrances == 2:
                     entrances_to_shuffle.add(entrance)
 
-            # Boss Entrances
-            if self.options.shuffle_boss_entrances.value > 0:
-                for entrance in SOHBossEntranceNames:
+            for entrance in SOHDungeonEntranceNames:
+                if entrance != SOHDungeonEntranceNames.GANONS_CASTLE_DUNGEON_ENTRANCE or self.options.shuffle_dungeon_entrances == 2:
                     entrances_to_shuffle.add(entrance)
 
-                if self.options.shuffle_boss_entrances.value == 1:
-                    entrance_groups_combined.update({SOHEntranceGroups.CHILD_BOSSES.value: [SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.CHILD_ONLY_BOSSES.value],
-                                                    SOHEntranceGroups.ADULT_BOSSES.value: [SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.ADULT_ONLY_BOSSES.value],
-                                                    SOHEntranceGroups.CHILD_ONLY_BOSSES.value: [SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.CHILD_ONLY_BOSSES.value],
-                                                    SOHEntranceGroups.ADULT_ONLY_BOSSES.value: [SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.ADULT_ONLY_BOSSES.value]})
-                else:
-                    entrance_groups_combined.update({SOHEntranceGroups.CHILD_ONLY_BOSSES.value: [SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.CHILD_ONLY_BOSSES.value],
-                                                    SOHEntranceGroups.ADULT_ONLY_BOSSES.value: [SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.ADULT_ONLY_BOSSES.value],
-                                                    SOHEntranceGroups.CHILD_BOSSES.value: [SOHEntranceGroups.CHILD_ONLY_BOSSES.value, SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.CHILD_BOSSES.value],
-                                                    SOHEntranceGroups.ADULT_BOSSES.value: [SOHEntranceGroups.ADULT_ONLY_BOSSES.value, SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.ADULT_BOSSES.value],
-                                                     })
+            # These groupings are currently really fiddly. They need to be tweaked for accuracy.
+            randomize_entrances_soh(
+                self, entrances_to_shuffle, {SOHEntranceGroups.BOTH_DUNGEONS.value: [SOHEntranceGroups.BOTH_DUNGEONS.value, SOHEntranceGroups.ADULT_DUNGEONS.value, SOHEntranceGroups.CHILD_DUNGEONS.value],
+                                             SOHEntranceGroups.CHILD_ONLY_DUNGEONS.value: [SOHEntranceGroups.CHILD_ONLY_DUNGEONS.value, SOHEntranceGroups.CHILD_DUNGEONS.value],
+                                             SOHEntranceGroups.ADULT_ONLY_DUNGEONS.value: [SOHEntranceGroups.ADULT_ONLY_DUNGEONS.value, SOHEntranceGroups.ADULT_DUNGEONS.value],
+                                             SOHEntranceGroups.CHILD_DUNGEONS.value: [SOHEntranceGroups.CHILD_DUNGEONS.value, SOHEntranceGroups.CHILD_ONLY_DUNGEONS.value, SOHEntranceGroups.ADULT_DUNGEONS.value, SOHEntranceGroups.BOTH_DUNGEONS.value],
+                                             SOHEntranceGroups.ADULT_DUNGEONS.value: [SOHEntranceGroups.ADULT_DUNGEONS.value, SOHEntranceGroups.ADULT_ONLY_DUNGEONS.value, SOHEntranceGroups.CHILD_DUNGEONS.value, SOHEntranceGroups.BOTH_DUNGEONS.value]})
 
-            for entranceEnum in entrances_to_shuffle:
-                disconnect_entrance_for_randomization(
-                    self.multiworld.get_entrance(entranceEnum.value, self.player), one_way_target_name=entrance_matching[entranceEnum].value)
+            entrances_to_shuffle.clear()
 
-            randomize_entrances(
-                self, True, entrance_groups_combined, True)
+        # Boss Entrances
+        if self.options.shuffle_boss_entrances.value > 0:
+            for entrance in SOHBossEntranceNames:
+                entrances_to_shuffle.add(entrance)
+
+            if self.options.shuffle_boss_entrances.value == 1:
+                randomize_entrances_soh(
+                    self, entrances_to_shuffle, {SOHEntranceGroups.CHILD_BOSSES.value: [SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.CHILD_ONLY_BOSSES.value],
+                                                 SOHEntranceGroups.ADULT_BOSSES.value: [SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.ADULT_ONLY_BOSSES.value],
+                                                 SOHEntranceGroups.CHILD_ONLY_BOSSES.value: [SOHEntranceGroups.CHILD_ONLY_BOSSES.value, SOHEntranceGroups.CHILD_BOSSES.value],
+                                                 SOHEntranceGroups.ADULT_ONLY_BOSSES.value: [SOHEntranceGroups.ADULT_ONLY_BOSSES.value, SOHEntranceGroups.ADULT_BOSSES.value]})
+            else:
+                randomize_entrances_soh(
+                    self, entrances_to_shuffle, {SOHEntranceGroups.CHILD_ONLY_BOSSES.value: [SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.CHILD_ONLY_BOSSES.value],
+                                                 SOHEntranceGroups.ADULT_ONLY_BOSSES.value: [SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.ADULT_ONLY_BOSSES.value],
+                                                 SOHEntranceGroups.CHILD_BOSSES.value: [SOHEntranceGroups.CHILD_ONLY_BOSSES.value, SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.CHILD_BOSSES.value],
+                                                 SOHEntranceGroups.ADULT_BOSSES.value: [SOHEntranceGroups.ADULT_ONLY_BOSSES.value, SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.ADULT_BOSSES.value]})
+
+            entrances_to_shuffle.clear()
 
         return super().connect_entrances()
 
@@ -248,11 +258,11 @@ class SohWorld(World):
         return changed
 
     # For debugging purposes
-    def generate_output(self, output_directory: str):
-        from Utils import visualize_regions
-        visualize_regions(self.get_region(self.origin_region_name), f"SOH-Player{self.player}.puml",
-                          show_entrance_names=True,
-                          regions_to_highlight=self.multiworld.get_all_state().reachable_regions[self.player])
+    # def generate_output(self, output_directory: str):
+    #     from Utils import visualize_regions
+    #     visualize_regions(self.get_region(self.origin_region_name), f"SOH-Player{self.player}.puml",
+    #                       show_entrance_names=True,
+    #                       regions_to_highlight=self.multiworld.get_all_state().reachable_regions[self.player])
 
     def fill_slot_data(self) -> dict[str, Any]:
         return {
@@ -335,4 +345,5 @@ class SohWorld(World):
             "ice_trap_count": self.options.ice_trap_count.value,
             "ice_trap_filler_replacement": self.options.ice_trap_filler_replacement.value,
             "apworld_version": self.apworld_version,
+            # Need to figure out how to get the randomized entrances to Ship
         }

--- a/worlds/oot_soh/__init__.py
+++ b/worlds/oot_soh/__init__.py
@@ -3,7 +3,8 @@ import pkgutil
 
 from typing import Any, List
 
-from BaseClasses import CollectionState, Item, Tutorial
+from BaseClasses import CollectionState, Item, Tutorial, Entrance
+from entrance_rando import disconnect_entrance_for_randomization, randomize_entrances
 from worlds.AutoWorld import WebWorld, World
 from .Items import SohItem, item_data_table, item_table, item_name_groups, progressive_items
 from .Locations import location_table
@@ -16,6 +17,7 @@ from .ShopItems import fill_shop_items, generate_scrub_prices, set_price_rules, 
 from Fill import fill_restrictive
 from .Presets import oot_soh_options_presets
 from .UniversalTracker import setup_options_from_slot_data
+from .EntranceShuffle import entrance_matching
 
 import logging
 logger = logging.getLogger("SOH_OOT")
@@ -85,6 +87,9 @@ class SohWorld(World):
         if self.options.shuffle_scrubs_minimum_price.value > self.options.shuffle_scrubs_maximum_price.value:
             self.options.shuffle_scrubs_maximum_price.value = self.options.shuffle_scrubs_minimum_price.value
 
+        # Entrance Rando stuff
+        self.explicit_indirect_conditions = True
+
     def create_regions(self) -> None:
         create_regions_and_locations(self)
         place_locked_items(self)
@@ -134,6 +139,42 @@ class SohWorld(World):
             self.shop_prices = self.passthrough["shop_prices"]
             self.shop_vanilla_items = self.passthrough["shop_vanilla_items"]
             set_price_rules(self)
+
+    def connect_entrances(self):
+        if self.options.shuffle_entrances.value:
+            entrances_to_shuffle = set()
+            entrance_groups_combined = dict()
+
+            # Dungeon Entrances
+            if self.options.shuffle_dungeon_entrances.value > 0:
+                for entrance in SOHBossEntranceNames:
+                    entrances_to_shuffle.add(entrance)
+
+            # Boss Entrances
+            if self.options.shuffle_boss_entrances.value > 0:
+                for entrance in SOHBossEntranceNames:
+                    entrances_to_shuffle.add(entrance)
+
+                if self.options.shuffle_boss_entrances.value == 1:
+                    entrance_groups_combined.update({SOHEntranceGroups.CHILD_BOSSES.value: [SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.CHILD_ONLY_BOSSES.value],
+                                                    SOHEntranceGroups.ADULT_BOSSES.value: [SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.ADULT_ONLY_BOSSES.value],
+                                                    SOHEntranceGroups.CHILD_ONLY_BOSSES.value: [SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.CHILD_ONLY_BOSSES.value],
+                                                    SOHEntranceGroups.ADULT_ONLY_BOSSES.value: [SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.ADULT_ONLY_BOSSES.value]})
+                else:
+                    entrance_groups_combined.update({SOHEntranceGroups.CHILD_ONLY_BOSSES.value: [SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.CHILD_ONLY_BOSSES.value],
+                                                    SOHEntranceGroups.ADULT_ONLY_BOSSES.value: [SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.ADULT_ONLY_BOSSES.value],
+                                                    SOHEntranceGroups.CHILD_BOSSES.value: [SOHEntranceGroups.CHILD_ONLY_BOSSES.value, SOHEntranceGroups.ADULT_BOSSES.value, SOHEntranceGroups.CHILD_BOSSES.value],
+                                                    SOHEntranceGroups.ADULT_BOSSES.value: [SOHEntranceGroups.ADULT_ONLY_BOSSES.value, SOHEntranceGroups.CHILD_BOSSES.value, SOHEntranceGroups.ADULT_BOSSES.value],
+                                                     })
+
+            for entranceEnum in entrances_to_shuffle:
+                disconnect_entrance_for_randomization(
+                    self.multiworld.get_entrance(entranceEnum.value, self.player), one_way_target_name=entrance_matching[entranceEnum].value)
+
+            randomize_entrances(
+                self, True, entrance_groups_combined, True)
+
+        return super().connect_entrances()
 
     def get_pre_fill_items(self) -> List["Item"]:
         pre_fill_items = []
@@ -207,11 +248,11 @@ class SohWorld(World):
         return changed
 
     # For debugging purposes
-    # def generate_output(self, output_directory: str):
-    #    from Utils import visualize_regions
-    #    visualize_regions(self.get_region(self.origin_region_name), f"SOH-Player{self.player}.puml",
-    #                      show_entrance_names=True,
-    #                      regions_to_highlight=self.multiworld.get_all_state().reachable_regions[self.player])
+    def generate_output(self, output_directory: str):
+        from Utils import visualize_regions
+        visualize_regions(self.get_region(self.origin_region_name), f"SOH-Player{self.player}.puml",
+                          show_entrance_names=True,
+                          regions_to_highlight=self.multiworld.get_all_state().reachable_regions[self.player])
 
     def fill_slot_data(self) -> dict[str, Any]:
         return {

--- a/worlds/oot_soh/location_access/dungeons/bottom_of_the_well.py
+++ b/worlds/oot_soh/location_access/dungeons/bottom_of_the_well.py
@@ -26,7 +26,8 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.BOTTOM_OF_THE_WELL_PERIMETER, lambda bundle: is_child(
             bundle) and can_pass_enemy(bundle, Enemies.BIG_SKULLTULA)),
         # [Regions.BOTTOM_OF_THE_WELL_MQ_PERIMETER, lambda bundle: is_child(bundle),
-        (Regions.KAK_WELL, lambda bundle: True)
+        (Regions.KAK_WELL, lambda bundle: True, SOHDungeonExitNames.BOTTOM_OF_THE_WELL_DUNGEON_EXIT,
+         SOHEntranceGroups.BOTH_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Bottom of the Well Perimeter

--- a/worlds/oot_soh/location_access/dungeons/deku_tree.py
+++ b/worlds/oot_soh/location_access/dungeons/deku_tree.py
@@ -30,7 +30,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.DEKU_TREE_ENTRYWAY, world, [
         (Regions.DEKU_TREE_LOBBY, lambda bundle: True),
-        (Regions.KF_OUTSIDE_DEKU_TREE, lambda bundle: True)
+        (Regions.KF_OUTSIDE_DEKU_TREE, lambda bundle: True, SOHDungeonExitNames.DEKU_TREE_DUNGEON_EXIT,
+         SOHEntranceGroups.CHILD_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Deku Lobby
@@ -55,6 +56,7 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Connections
     connect_regions(Regions.DEKU_TREE_LOBBY, world, [
+        (Regions.DEKU_TREE_ENTRYWAY, lambda bundle: True),
         (Regions.DEKU_TREE_2F_MIDDLE_ROOM, lambda bundle: True),
         (Regions.DEKU_TREE_COMPASS_ROOM, lambda bundle: True),
         (Regions.DEKU_TREE_BASEMENT_LOWER, lambda bundle: can_attack(

--- a/worlds/oot_soh/location_access/dungeons/deku_tree.py
+++ b/worlds/oot_soh/location_access/dungeons/deku_tree.py
@@ -275,7 +275,7 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.DEKU_TREE_OUTSIDE_BOSS_ROOM, world, [
         (Regions.DEKU_TREE_BASEMENT_UPPER, lambda bundle: True),
         (Regions.DEKU_TREE_BOSS_ENTRYWAY, lambda bundle: (has_item(Items.BRONZE_SCALE, bundle) or can_use(Items.IRON_BOOTS, bundle))
-            and can_reflect_nuts(bundle))
+            and can_reflect_nuts(bundle), SOHBossEntranceNames.DEKU_TREE_BOSS_ENTRANCE, SOHEntranceGroups.CHILD_BOSSES, EntranceType.ONE_WAY)
     ])
 
     # Skipping master quest for now

--- a/worlds/oot_soh/location_access/dungeons/dodongos_cavern.py
+++ b/worlds/oot_soh/location_access/dungeons/dodongos_cavern.py
@@ -70,7 +70,7 @@ def set_region_rules(world: "SohWorld") -> None:
          lambda bundle: has_item(LocalEvents.DODONGOS_CAVERN_LIFT_PLATFORM, bundle)),
         (Regions.DODONGOS_CAVERN_BOSS_REGION, lambda bundle: has_item(
             LocalEvents.DODONGOS_CAVERN_EYES_LIT, bundle)),
-        (Regions.DODONGOS_CAVERN_BOSS_ENTRYWAY, lambda bundle: False),
+        # (Regions.DODONGOS_CAVERN_BOSS_ENTRYWAY, lambda bundle: False),
     ])
 
     # Dodongos Cavern Lobby Switch
@@ -402,7 +402,8 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.DODONGOS_CAVERN_LOBBY, lambda bundle: True),
         (Regions.DODONGOS_CAVERN_BACK_ROOM,
          lambda bundle: can_break_mud_walls(bundle)),
-        (Regions.DODONGOS_CAVERN_BOSS_ENTRYWAY, lambda bundle: True),
+        (Regions.DODONGOS_CAVERN_BOSS_ENTRYWAY, lambda bundle: True, SOHBossEntranceNames.DODONGOS_CAVERN_BOSS_ENTRANCE,
+         SOHEntranceGroups.CHILD_BOSSES, EntranceType.ONE_WAY),
     ])
 
     # Dodongos Cavern Back Room

--- a/worlds/oot_soh/location_access/dungeons/dodongos_cavern.py
+++ b/worlds/oot_soh/location_access/dungeons/dodongos_cavern.py
@@ -26,9 +26,9 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.DODONGOS_CAVERN_ENTRYWAY, world, [
         (Regions.DODONGOS_CAVERN_BEGINNING, lambda bundle: True),
-        (Regions.DEATH_MOUNTAIN_TRAIL, lambda bundle: True),
+        (Regions.DEATH_MOUNTAIN_TRAIL, lambda bundle: True, SOHDungeonExitNames.DODONGOS_CAVERN_DUNGEON_EXIT,
+         SOHEntranceGroups.BOTH_DUNGEONS, EntranceType.TWO_WAY),
     ])
-
     # Dodongos Cavern Beginning
     # Connections
     connect_regions(Regions.DODONGOS_CAVERN_BEGINNING, world, [

--- a/worlds/oot_soh/location_access/dungeons/fire_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/fire_temple.py
@@ -21,7 +21,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.FIRE_TEMPLE_ENTRYWAY, world, [
         (Regions.FIRE_TEMPLE_FIRST_ROOM, lambda bundle: True),
-        (Regions.DMC_CENTRAL_LOCAL, lambda bundle: True)
+        (Regions.DMC_CENTRAL_LOCAL, lambda bundle: True, SOHDungeonExitNames.FIRE_TEMPLE_DUNGEON_EXIT,
+         SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Fire Temple First Room
@@ -66,7 +67,7 @@ def set_region_rules(world: "SohWorld") -> None:
             (is_adult(bundle) and
              (can_do_trick(Tricks.FIRE_BOSS_DOOR_JUMP, bundle) or
               has_item(LocalEvents.FIRE_TEMPLE_FIRE_MAZE_UPPER_PLATFORM_HIT, bundle) or
-              can_use(Items.HOVER_BOOTS, bundle))), SOHBossEntranceNames.FIRE_TEMPLE_BOSS_ENTRANCE, SOHEntranceGroups.ADULT_ONLY_BOSSES, EntranceType.ONE_WAY)
+              can_use(Items.HOVER_BOOTS, bundle))), SOHBossEntranceNames.FIRE_TEMPLE_BOSS_ENTRANCE, SOHEntranceGroups.ADULT_BOSSES, EntranceType.ONE_WAY)
     ])
 
     # Fire Temple Loop Enemies

--- a/worlds/oot_soh/location_access/dungeons/fire_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/fire_temple.py
@@ -66,7 +66,7 @@ def set_region_rules(world: "SohWorld") -> None:
             (is_adult(bundle) and
              (can_do_trick(Tricks.FIRE_BOSS_DOOR_JUMP, bundle) or
               has_item(LocalEvents.FIRE_TEMPLE_FIRE_MAZE_UPPER_PLATFORM_HIT, bundle) or
-              can_use(Items.HOVER_BOOTS, bundle))))
+              can_use(Items.HOVER_BOOTS, bundle))), SOHBossEntranceNames.FIRE_TEMPLE_BOSS_ENTRANCE, SOHEntranceGroups.ADULT_ONLY_BOSSES, EntranceType.ONE_WAY)
     ])
 
     # Fire Temple Loop Enemies

--- a/worlds/oot_soh/location_access/dungeons/forest_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/forest_temple.py
@@ -510,7 +510,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.FOREST_TEMPLE_BOSS_REGION, world, [
         (Regions.FOREST_TEMPLE_LOBBY, lambda bundle: True),
-        (Regions.FOREST_TEMPLE_BOSS_ENTRYWAY, lambda bundle: True)
+        (Regions.FOREST_TEMPLE_BOSS_ENTRYWAY, lambda bundle: True, SOHBossEntranceNames.FOREST_TEMPLE_BOSS_ENTRANCE,
+         SOHEntranceGroups.ADULT_BOSSES, EntranceType.ONE_WAY)
     ])
 
     # Forest Temple Boss Entryway

--- a/worlds/oot_soh/location_access/dungeons/forest_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/forest_temple.py
@@ -36,7 +36,8 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.FOREST_TEMPLE_ENTRYWAY, world, [
         # Todo: Change this when we have IsVanilla vs. IsMQ
         (Regions.FOREST_TEMPLE_FIRST_ROOM, lambda bundle: True),
-        (Regions.SACRED_FOREST_MEADOW, lambda bundle: True)
+        (Regions.SACRED_FOREST_MEADOW, lambda bundle: True, SOHDungeonExitNames.FOREST_TEMPLE_DUNGEON_EXIT,
+         SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Forest Temple First Room

--- a/worlds/oot_soh/location_access/dungeons/ganons_castle.py
+++ b/worlds/oot_soh/location_access/dungeons/ganons_castle.py
@@ -32,7 +32,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.GANONS_CASTLE_ENTRYWAY, world, [
         (Regions.GANONS_CASTLE_LOBBY, lambda bundle: True),
-        (Regions.CASTLE_GROUNDS_FROM_GANONS_CASTLE, lambda bundle: True)
+        (Regions.GANONS_CASTLE_LEDGE, lambda bundle: True,
+         SOHDungeonExitNames.GANONS_CASTLE_DUNGEON_EXIT, SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Ganon's Castle Lobby

--- a/worlds/oot_soh/location_access/dungeons/gerudo_training_ground.py
+++ b/worlds/oot_soh/location_access/dungeons/gerudo_training_ground.py
@@ -9,7 +9,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.GERUDO_TRAINING_GROUND_ENTRYWAY, world, [
         (Regions.GERUDO_TRAINING_GROUND_LOBBY, lambda bundle: True),
-        (Regions.GF_EXITING_GTG, lambda bundle: True),
+        (Regions.GF_TO_GTG, lambda bundle: True, SOHDungeonExitNames.GERUDO_TRAINING_GROUND_DUNGEON_EXIT,
+         SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY),
     ])
 
     # Gerudo Training Ground Lobby

--- a/worlds/oot_soh/location_access/dungeons/ice_cavern.py
+++ b/worlds/oot_soh/location_access/dungeons/ice_cavern.py
@@ -10,13 +10,12 @@ class EventLocations(StrEnum):
 
 def set_region_rules(world: "SohWorld") -> None:
     # Ice Cavern Entryway
-    # Locations
-    add_locations(Regions.ICE_CAVERN_ENTRYWAY, world, [])
     # Connections
     connect_regions(Regions.ICE_CAVERN_ENTRYWAY, world, [
         (Regions.ICE_CAVERN_BEGINNING, lambda bundle: True),
         # Skipping MQ
-        (Regions.ZF_LEDGE, lambda bundle: True)
+        (Regions.ZF_LEDGE, lambda bundle: True, SOHDungeonExitNames.ICE_CAVERN_DUNGEON_EXIT,
+         SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Ice Cavern Beginning

--- a/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
+++ b/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
@@ -31,7 +31,8 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.JABU_JABUS_BELLY_ENTRYWAY, world, [
         # TODO: Add vanilla/MQ check
         (Regions.JABU_JABUS_BELLY_BEGINNING, lambda bundle: True),
-        (Regions.ZORAS_FOUNTAIN, lambda bundle: True)
+        (Regions.ZORAS_FOUNTAIN, lambda bundle: True, SOHDungeonExitNames.JABU_JABUS_DUNGEON_EXIT,
+         SOHEntranceGroups.CHILD_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Jabu Jabu's Belly Beginning

--- a/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
+++ b/worlds/oot_soh/location_access/dungeons/jabujabus_belly.py
@@ -245,7 +245,7 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.JABU_JABUS_BELLY_NEAR_BOSS_ROOM, world, [
         (Regions.JABU_JABUS_BELLY_MAIN, lambda bundle: True),
         (Regions.JABU_JABUS_BELLY_BOSS_ENTRYWAY, lambda bundle: can_use(Items.BOOMERANG, bundle) or (can_do_trick(Tricks.JABU_NEAR_BOSS_RANGED, bundle) and can_use_any([Items.HOOKSHOT, Items.FAIRY_BOW, Items.FAIRY_SLINGSHOT], bundle)) or (
-            can_do_trick(Tricks.JABU_NEAR_BOSS_EXPLOSIVES, bundle) and (can_use(Items.BOMBCHUS_5, bundle) or (can_use(Items.HOVER_BOOTS, bundle) and can_use(Items.BOMB_BAG, bundle)))))
+            can_do_trick(Tricks.JABU_NEAR_BOSS_EXPLOSIVES, bundle) and (can_use(Items.BOMBCHUS_5, bundle) or (can_use(Items.HOVER_BOOTS, bundle) and can_use(Items.BOMB_BAG, bundle)))), SOHBossEntranceNames.JABU_JABUS_BOSS_ENTRANCE, SOHEntranceGroups.CHILD_ONLY_BOSSES, EntranceType.ONE_WAY)
     ])
 
     # Skipping master quest for now

--- a/worlds/oot_soh/location_access/dungeons/shadow_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/shadow_temple.py
@@ -16,7 +16,8 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.SHADOW_TEMPLE_ENTRYWAY, world, [
         (Regions.SHADOW_TEMPLE_BEGINNING, lambda bundle: (can_do_trick(Tricks.LENS_SHADOW, bundle) or can_use(
             Items.LENS_OF_TRUTH, bundle)) and (can_use(Items.HOVER_BOOTS, bundle) or can_use(Items.HOOKSHOT, bundle))),
-        (Regions.GRAVEYARD_WARP_PAD_REGION, lambda bundle: True)
+        (Regions.GRAVEYARD_WARP_PAD_REGION, lambda bundle: True,
+         SOHDungeonExitNames.SHADOW_TEMPLE_DUNGEON_EXIT, SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Shadow Temple Beginning
@@ -177,8 +178,8 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Connections
     connect_regions(Regions.SHADOW_TEMPLE_BEYOND_BOAT, world, [
-        (Regions.SHADOW_TEMPLE_BOSS_ENTRYWAY, lambda bundle: (can_use(Items.FAIRY_BOW, bundle) or can_use(Items.DISTANT_SCARECROW, bundle) or (can_do_trick(
-            Tricks.SHADOW_STATUE, bundle) and can_use(Items.BOMBCHUS_5, bundle))) and small_keys(Items.SHADOW_TEMPLE_SMALL_KEY, 5, bundle) and can_use(Items.HOVER_BOOTS, bundle), SOHBossEntranceNames.SHADOW_TEMPLE_BOSS_ENTRANCE, SOHEntranceGroups.ADULT_BOSSES, EntranceType.ONE_WAY),
+        (Regions.SHADOW_TEMPLE_BOSS_ENTRYWAY, lambda bundle: (can_use(Items.FAIRY_BOW, bundle) or can_use(Items.DISTANT_SCARECROW, bundle) or (can_do_trick(Tricks.SHADOW_STATUE, bundle) and can_use(Items.BOMBCHUS_5, bundle)))
+         and small_keys(Items.SHADOW_TEMPLE_SMALL_KEY, 5, bundle) and can_use(Items.HOVER_BOOTS, bundle), SOHBossEntranceNames.SHADOW_TEMPLE_BOSS_ENTRANCE, SOHEntranceGroups.ADULT_BOSSES, EntranceType.ONE_WAY),
     ])
 
     # Shadow Temple Boss Entryway

--- a/worlds/oot_soh/location_access/dungeons/shadow_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/shadow_temple.py
@@ -178,7 +178,7 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.SHADOW_TEMPLE_BEYOND_BOAT, world, [
         (Regions.SHADOW_TEMPLE_BOSS_ENTRYWAY, lambda bundle: (can_use(Items.FAIRY_BOW, bundle) or can_use(Items.DISTANT_SCARECROW, bundle) or (can_do_trick(
-            Tricks.SHADOW_STATUE, bundle) and can_use(Items.BOMBCHUS_5, bundle))) and small_keys(Items.SHADOW_TEMPLE_SMALL_KEY, 5, bundle) and can_use(Items.HOVER_BOOTS, bundle)),
+            Tricks.SHADOW_STATUE, bundle) and can_use(Items.BOMBCHUS_5, bundle))) and small_keys(Items.SHADOW_TEMPLE_SMALL_KEY, 5, bundle) and can_use(Items.HOVER_BOOTS, bundle), SOHBossEntranceNames.SHADOW_TEMPLE_BOSS_ENTRANCE, SOHEntranceGroups.ADULT_BOSSES, EntranceType.ONE_WAY),
     ])
 
     # Shadow Temple Boss Entryway

--- a/worlds/oot_soh/location_access/dungeons/spirit_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/spirit_temple.py
@@ -203,7 +203,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.SPIRIT_TEMPLE_INSIDE_STATUE_HEAD, world, [
         (Regions.SPIRIT_TEMPLE_CENTRAL_CHAMBER, lambda bundle: True),
-        (Regions.SPIRIT_TEMPLE_BOSS_ENTRYWAY, lambda bundle: True)
+        (Regions.SPIRIT_TEMPLE_BOSS_ENTRYWAY, lambda bundle: True, SOHBossEntranceNames.SPIRIT_TEMPLE_BOSS_ENTRANCE,
+         SOHEntranceGroups.ADULT_BOSSES, EntranceType.ONE_WAY)
     ])
 
     # Spirit Temple Boss Entryway

--- a/worlds/oot_soh/location_access/dungeons/spirit_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/spirit_temple.py
@@ -14,7 +14,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.SPIRIT_TEMPLE_ENTRYWAY, world, [
         (Regions.SPIRIT_TEMPLE_LOBBY, lambda bundle: True),
-        (Regions.DESERT_COLOSSUS_OUTSIDE_TEMPLE, lambda bundle: True)
+        (Regions.DESERT_COLOSSUS, lambda bundle: True, SOHDungeonExitNames.SPIRIT_TEMPLE_DUNGEON_EXIT,
+         SOHEntranceGroups.BOTH_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Spirit Temple Lobby
@@ -204,7 +205,7 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.SPIRIT_TEMPLE_INSIDE_STATUE_HEAD, world, [
         (Regions.SPIRIT_TEMPLE_CENTRAL_CHAMBER, lambda bundle: True),
         (Regions.SPIRIT_TEMPLE_BOSS_ENTRYWAY, lambda bundle: True, SOHBossEntranceNames.SPIRIT_TEMPLE_BOSS_ENTRANCE,
-         SOHEntranceGroups.ADULT_BOSSES, EntranceType.ONE_WAY)
+         SOHEntranceGroups.ADULT_ONLY_BOSSES, EntranceType.ONE_WAY)
     ])
 
     # Spirit Temple Boss Entryway

--- a/worlds/oot_soh/location_access/dungeons/water_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/water_temple.py
@@ -559,7 +559,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.WATER_TEMPLE_PRE_BOSS_ROOM, world, [
         (Regions.WATER_TEMPLE_LOBBY, lambda bundle: True),
-        (Regions.WATER_TEMPLE_BOSS_ENTRYWAY, lambda bundle: True)
+        (Regions.WATER_TEMPLE_BOSS_ENTRYWAY, lambda bundle: True, SOHBossEntranceNames.WATER_TEMPLE_BOSS_ENTRANCE,
+         SOHEntranceGroups.ADULT_ONLY_BOSSES, EntranceType.ONE_WAY)
     ])
 
     # Water Temple Boss Entryway

--- a/worlds/oot_soh/location_access/dungeons/water_temple.py
+++ b/worlds/oot_soh/location_access/dungeons/water_temple.py
@@ -25,7 +25,8 @@ def set_region_rules(world: "SohWorld") -> None:
     connect_regions(Regions.WATER_TEMPLE_ENTRYWAY, world, [
         (Regions.WATER_TEMPLE_LOBBY, lambda bundle: (
             has_item(Items.BRONZE_SCALE, bundle))),
-        (Regions.LH_FROM_WATER_TEMPLE, lambda bundle: True)
+        (Regions.LH_FROM_WATER_TEMPLE, lambda bundle: True, SOHDungeonExitNames.WATER_TEMPLE_DUNGEON_EXIT,
+         SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Water Temple Lobby

--- a/worlds/oot_soh/location_access/overworld/castle_grounds.py
+++ b/worlds/oot_soh/location_access/overworld/castle_grounds.py
@@ -181,17 +181,20 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.CASTLE_GROUNDS, lambda bundle: True)
     ])
 
-    # Castle Grounds from Ganon's Castle
-    # Connections
-    connect_regions(Regions.CASTLE_GROUNDS_FROM_GANONS_CASTLE, world, [
-        (Regions.HYRULE_CASTLE_GROUNDS, lambda bundle: is_child(bundle)),
-        (Regions.GANONS_CASTLE_LEDGE, lambda bundle: is_adult(bundle))
-    ])
+    # Deviation from Ship, but makes ER easier
+    # # Castle Grounds from Ganon's Castle
+    # # Connections
+    # connect_regions(Regions.CASTLE_GROUNDS_FROM_GANONS_CASTLE, world, [
+    #     (Regions.HYRULE_CASTLE_GROUNDS, lambda bundle: is_child(bundle)),
+    #     (Regions.GANONS_CASTLE_LEDGE, lambda bundle: is_adult(bundle))
+    # ])
 
     # Ganon's Castle Ledge
     # Connections
     connect_regions(Regions.GANONS_CASTLE_LEDGE, world, [
-        (Regions.GANONS_CASTLE_GROUNDS, lambda bundle: has_item(
-            LocalEvents.HC_OGC_RAINBOW_BRIDGE_BUILT, bundle)),
-        (Regions.GANONS_CASTLE_ENTRYWAY, lambda bundle: is_adult(bundle))
+        (Regions.GANONS_CASTLE_GROUNDS, lambda bundle: is_adult(bundle)
+         and has_item(LocalEvents.HC_OGC_RAINBOW_BRIDGE_BUILT, bundle)),
+        (Regions.HYRULE_CASTLE_GROUNDS, lambda bundle: is_child(bundle)),
+        (Regions.GANONS_CASTLE_ENTRYWAY, lambda bundle: is_adult(bundle),
+         SOHDungeonEntranceNames.GANONS_CASTLE_DUNGEON_ENTRANCE, SOHEntranceGroups.ADULT_ONLY_DUNGEONS, EntranceType.TWO_WAY)
     ])

--- a/worlds/oot_soh/location_access/overworld/death_mountain_crater.py
+++ b/worlds/oot_soh/location_access/overworld/death_mountain_crater.py
@@ -52,9 +52,8 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.DMC_UPPER_NEARBY, lambda bundle: True),
         (Regions.DMC_LADDER_REGION_NEARBY, lambda bundle: fire_timer(
             bundle) >= 16 or hearts(bundle) >= 3),
-        (Regions.DMC_CENTRAL_NEARBY, lambda bundle: is_adult(bundle) and can_use(Items.GORON_TUNIC, bundle) and can_use(Items.DISTANT_SCARECROW, bundle) and (effective_health(
-            # TODO Implement Dungeon Shuffle Option to replace False
-            bundle) > 2 or (can_use(Items.BOTTLE_WITH_FAIRY, bundle) and False or can_use(Items.NAYRUS_LOVE, bundle)))),
+        (Regions.DMC_CENTRAL_NEARBY, lambda bundle: is_adult(bundle) and can_use(Items.GORON_TUNIC, bundle) and can_use(Items.DISTANT_SCARECROW, bundle) and (
+            effective_health(bundle) > 2 or (can_use(Items.BOTTLE_WITH_FAIRY, bundle) and world.options.shuffle_dungeon_entrances.value > 0) or can_use(Items.NAYRUS_LOVE, bundle))),
         (Regions.DMC_LOWER_NEARBY, lambda bundle: False),
         (Regions.DMC_DISTANT_PLATFORM, lambda bundle: (fire_timer(
             bundle) >= 48 or hearts(bundle) >= 2) or hearts(bundle) >= 3),
@@ -162,9 +161,8 @@ def set_region_rules(world: "SohWorld") -> None:
          bundle)) or can_use(Items.HOVER_BOOTS, bundle) or can_use(Items.HOOKSHOT, bundle)),
         (Regions.DMC_UPPER_NEARBY, lambda bundle: is_adult(bundle)
          and has_item(LocalEvents.DMC_BEAN_PLANTED, bundle)),
-        (Regions.FIRE_TEMPLE_ENTRYWAY, lambda bundle: (is_child(bundle) and hearts(bundle) >= 3 and False) or (
-            # TODO Implement Dungeon Shuffle Option to replace False
-            is_adult(bundle) and fire_timer(bundle) >= 24)),
+        (Regions.FIRE_TEMPLE_ENTRYWAY, lambda bundle: (is_child(bundle) and hearts(bundle) >= 3 and world.options.shuffle_dungeon_entrances.value > 0) or (
+            is_adult(bundle) and fire_timer(bundle) >= 24), SOHDungeonEntranceNames.FIRE_TEMPLE_DUNGEON_ENTRANCE, SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY),
         (Regions.DMC_DISTANT_PLATFORM, lambda bundle: (fire_timer(bundle) >=
          48 or hearts(bundle) >= 2) and can_use(Items.DISTANT_SCARECROW, bundle)),
     ])
@@ -204,10 +202,14 @@ def set_region_rules(world: "SohWorld") -> None:
          lambda bundle: can_break_lower_hives(bundle)),
         (Locations.DMC_UPPER_GROTTO_BEEHIVE_RIGHT,
          lambda bundle: can_break_lower_hives(bundle)),
-        (Locations.DMC_UPPER_GROTTO_GRASS1, lambda bundle: can_cut_shrubs(bundle)),
-        (Locations.DMC_UPPER_GROTTO_GRASS2, lambda bundle: can_cut_shrubs(bundle)),
-        (Locations.DMC_UPPER_GROTTO_GRASS3, lambda bundle: can_cut_shrubs(bundle)),
-        (Locations.DMC_UPPER_GROTTO_GRASS4, lambda bundle: can_cut_shrubs(bundle))
+        (Locations.DMC_UPPER_GROTTO_GRASS1,
+         lambda bundle: can_cut_shrubs(bundle)),
+        (Locations.DMC_UPPER_GROTTO_GRASS2,
+         lambda bundle: can_cut_shrubs(bundle)),
+        (Locations.DMC_UPPER_GROTTO_GRASS3,
+         lambda bundle: can_cut_shrubs(bundle)),
+        (Locations.DMC_UPPER_GROTTO_GRASS4,
+         lambda bundle: can_cut_shrubs(bundle))
     ])
     # Connections
     connect_regions(Regions.DMC_UPPER_GROTTO, world, [
@@ -234,13 +236,20 @@ def set_region_rules(world: "SohWorld") -> None:
     # Death Mountain Crater Distant Platform
     # Locations
     add_locations(Regions.DMC_DISTANT_PLATFORM, world, [
-        (Locations.DMC_DISTANT_PLATFORM_RUPEE1, lambda bundle: is_adult(bundle)),
-        (Locations.DMC_DISTANT_PLATFORM_RUPEE2, lambda bundle: is_adult(bundle)),
-        (Locations.DMC_DISTANT_PLATFORM_RUPEE3, lambda bundle: is_adult(bundle)),
-        (Locations.DMC_DISTANT_PLATFORM_RUPEE4, lambda bundle: is_adult(bundle)),
-        (Locations.DMC_DISTANT_PLATFORM_RUPEE5, lambda bundle: is_adult(bundle)),
-        (Locations.DMC_DISTANT_PLATFORM_RUPEE6, lambda bundle: is_adult(bundle)),
-        (Locations.DMC_DISTANT_PLATFORM_RED_RUPEE, lambda bundle: is_adult(bundle))
+        (Locations.DMC_DISTANT_PLATFORM_RUPEE1,
+         lambda bundle: is_adult(bundle)),
+        (Locations.DMC_DISTANT_PLATFORM_RUPEE2,
+         lambda bundle: is_adult(bundle)),
+        (Locations.DMC_DISTANT_PLATFORM_RUPEE3,
+         lambda bundle: is_adult(bundle)),
+        (Locations.DMC_DISTANT_PLATFORM_RUPEE4,
+         lambda bundle: is_adult(bundle)),
+        (Locations.DMC_DISTANT_PLATFORM_RUPEE5,
+         lambda bundle: is_adult(bundle)),
+        (Locations.DMC_DISTANT_PLATFORM_RUPEE6,
+         lambda bundle: is_adult(bundle)),
+        (Locations.DMC_DISTANT_PLATFORM_RED_RUPEE,
+         lambda bundle: is_adult(bundle))
     ])
     # Connections
     connect_regions(Regions.DMC_DISTANT_PLATFORM, world, [

--- a/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
+++ b/worlds/oot_soh/location_access/overworld/death_mountain_trail.py
@@ -60,8 +60,8 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.GORON_CITY, lambda bundle: True),
         (Regions.DEATH_MOUNTAIN_SUMMIT, lambda bundle: blast_or_smash(bundle) or (is_adult(bundle) and ((has_item(LocalEvents.DMT_BEAN_PLANTED, bundle)
          and has_item(Items.GORONS_BRACELET, bundle)) or (can_use(Items.HOVER_BOOTS, bundle) and can_do_trick(Tricks.DMT_CLIMB_HOVERS, bundle))))),
-        (Regions.DODONGOS_CAVERN_ENTRYWAY, lambda bundle: has_explosives(
-            bundle) or has_item(Items.GORONS_BRACELET, bundle) or is_adult(bundle)),
+        (Regions.DODONGOS_CAVERN_ENTRYWAY, lambda bundle: has_explosives(bundle) or has_item(Items.GORONS_BRACELET, bundle) or is_adult(
+            bundle), SOHDungeonEntranceNames.DODONGOS_CAVERN_DUNGEON_ENTRANCE, SOHEntranceGroups.BOTH_DUNGEONS, EntranceType.TWO_WAY),
         (Regions.DMT_STORMS_GROTTO, lambda bundle: can_open_storms_grotto(bundle))
     ])
 

--- a/worlds/oot_soh/location_access/overworld/desert_colossus.py
+++ b/worlds/oot_soh/location_access/overworld/desert_colossus.py
@@ -45,7 +45,8 @@ def set_region_rules(world: "SohWorld") -> None:
         (Locations.COLOSSUS_GOSSIP_STONE_FAIRY,
          lambda bundle: call_gossip_fairy(bundle)),
         (Locations.COLOSSUS_GOSSIP_STONE_BIG_FAIRY,
-         lambda bundle: can_use(Items.SONG_OF_STORMS, bundle))
+         lambda bundle: can_use(Items.SONG_OF_STORMS, bundle)),
+        (Locations.SHEIK_AT_COLOSSUS, lambda bundle: True)
 
     ])
     # Connections
@@ -54,7 +55,8 @@ def set_region_rules(world: "SohWorld") -> None:
             has_item(Items.BRONZE_SCALE, bundle) or can_use(Items.IRON_BOOTS, bundle))),
         (Regions.COLOSSUS_GREAT_FAIRY_FOUNTAIN,
          lambda bundle: has_explosives(bundle)),
-        (Regions.SPIRIT_TEMPLE_ENTRYWAY, lambda bundle: True),
+        (Regions.SPIRIT_TEMPLE_ENTRYWAY, lambda bundle: True, SOHDungeonEntranceNames.SPIRIT_TEMPLE_DUNGEON_ENTRNACE,
+         SOHEntranceGroups.BOTH_DUNGEONS, EntranceType.TWO_WAY),
         (Regions.WASTELAND_NEAR_COLOSSUS, lambda bundle: True),
         (Regions.COLOSSUS_GROTTO, lambda bundle: can_use(
             Items.SILVER_GAUNTLETS, bundle))
@@ -83,15 +85,15 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.DESERT_COLOSSUS, lambda bundle: True)
     ])
 
-    # Desert Colossus Outside Temple
-    # Locations
-    add_locations(Regions.DESERT_COLOSSUS_OUTSIDE_TEMPLE, world, [
-        (Locations.SHEIK_AT_COLOSSUS, lambda bundle: True)
-    ])
-    # Connections
-    connect_regions(Regions.DESERT_COLOSSUS_OUTSIDE_TEMPLE, world, [
-        (Regions.DESERT_COLOSSUS, lambda bundle: True)
-    ])
+    # # Desert Colossus Outside Temple
+    # # Locations
+    # add_locations(Regions.DESERT_COLOSSUS_OUTSIDE_TEMPLE, world, [
+    #     (Locations.SHEIK_AT_COLOSSUS, lambda bundle: True)
+    # ])
+    # # Connections
+    # connect_regions(Regions.DESERT_COLOSSUS_OUTSIDE_TEMPLE, world, [
+    #     (Regions.DESERT_COLOSSUS, lambda bundle: True)
+    # ])
 
     # Desert Colossus Great Fairy Fountain
     # Locations

--- a/worlds/oot_soh/location_access/overworld/gerudo_fortress.py
+++ b/worlds/oot_soh/location_access/overworld/gerudo_fortress.py
@@ -80,9 +80,7 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Connections
     connect_regions(Regions.GF_OUTSIDE_GTG, world, [
-        # TODO: Check for entrance rando
-        (Regions.GF_TO_GTG, lambda bundle: has_item(
-            LocalEvents.GTG_GATE_OPEN, bundle) and is_adult(bundle)),
+        (Regions.GF_TO_GTG, lambda bundle: True),
         (Regions.GF_JAIL_WINDOW, lambda bundle: can_use(Items.HOOKSHOT, bundle)),
         (Regions.GERUDO_FORTRESS_OUTSKIRTS, lambda bundle: True),
         (Regions.GF_NEAR_GROTTO, lambda bundle: is_child(bundle)
@@ -98,17 +96,23 @@ def set_region_rules(world: "SohWorld") -> None:
     # GF to GTG
     # Connections
     connect_regions(Regions.GF_TO_GTG, world, [
-        (Regions.GERUDO_TRAINING_GROUND_ENTRYWAY, lambda bundle: True),
-    ])
-
-    # GF Exiting GTG
-    # Connections
-    connect_regions(Regions.GF_EXITING_GTG, world, [
+        (Regions.GERUDO_TRAINING_GROUND_ENTRYWAY, lambda bundle: has_item(LocalEvents.GTG_GATE_OPEN, bundle) and (is_adult(bundle) or world.options.shuffle_dungeon_entrances >
+         0), SOHDungeonEntranceNames.GERUDO_TRAINING_GROUND_DUNGEON_ENTRANCE, SOHEntranceGroups.ADULT_DUNGEONS, EntranceType.TWO_WAY),
         (Regions.GF_OUTSIDE_GTG, lambda bundle: is_child(bundle)
          or has_item(Items.GERUDO_MEMBERSHIP_CARD, bundle)),
         (Regions.GF_JAIL_WINDOW, lambda bundle: can_use(Items.HOOKSHOT, bundle)),
         (Regions.GERUDO_FORTRESS_OUTSKIRTS, lambda bundle: True),
     ])
+
+    # Deviation from Ship
+    # GF Exiting GTG
+    # Connections
+    # connect_regions(Regions.GF_EXITING_GTG, world, [
+    #     (Regions.GF_OUTSIDE_GTG, lambda bundle: is_child(bundle)
+    #      or has_item(Items.GERUDO_MEMBERSHIP_CARD, bundle)),
+    #     (Regions.GF_JAIL_WINDOW, lambda bundle: can_use(Items.HOOKSHOT, bundle)),
+    #     (Regions.GERUDO_FORTRESS_OUTSKIRTS, lambda bundle: True),
+    # ])
 
     # GF Above GTG
     # Connections

--- a/worlds/oot_soh/location_access/overworld/graveyard.py
+++ b/worlds/oot_soh/location_access/overworld/graveyard.py
@@ -199,6 +199,6 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.GRAVEYARD_WARP_PAD_REGION, world, [
         (Regions.THE_GRAVEYARD, lambda bundle: True),
-        (Regions.SHADOW_TEMPLE_ENTRYWAY, lambda bundle: can_use(Items.DINS_FIRE, bundle) or (can_do_trick(
-            Tricks.GY_SHADOW_FIRE_ARROWS, bundle) and is_adult(bundle) and can_use(Items.FIRE_ARROW, bundle)))
+        (Regions.SHADOW_TEMPLE_ENTRYWAY, lambda bundle: can_use(Items.DINS_FIRE, bundle) or (can_do_trick(Tricks.GY_SHADOW_FIRE_ARROWS, bundle) and is_adult(
+            bundle) and can_use(Items.FIRE_ARROW, bundle)), SOHDungeonEntranceNames.SHADOW_TEMPLE_DUNGEON_ENTRANCE, SOHEntranceGroups.BOTH_DUNGEONS, EntranceType.TWO_WAY)
     ])

--- a/worlds/oot_soh/location_access/overworld/kakariko.py
+++ b/worlds/oot_soh/location_access/overworld/kakariko.py
@@ -430,9 +430,7 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.KAK_WELL, world, [
         (Regions.KAKARIKO_VILLAGE,
-         lambda bundle: is_adult(bundle) or has_item(Items.BRONZE_SCALE, bundle) or has_item(Events.DRAIN_WELL,
-                                                                                             bundle)),
-        # TODO: Add check for dungeon entrance randomization
-        (Regions.BOTTOM_OF_THE_WELL_ENTRYWAY, lambda bundle: is_child(
-            bundle) or has_item(Events.DRAIN_WELL, bundle)),
+         lambda bundle: is_adult(bundle) or has_item(Items.BRONZE_SCALE, bundle) or has_item(Events.DRAIN_WELL, bundle)),
+        (Regions.BOTTOM_OF_THE_WELL_ENTRYWAY, lambda bundle: is_child(bundle) or (has_item(Events.DRAIN_WELL, bundle) and world.options.shuffle_dungeon_entrances.value >
+         0), SOHDungeonEntranceNames.BOTTOM_OF_THE_WELL_DUNGEON_ENTRANCE, SOHEntranceGroups.BOTH_DUNGEONS, EntranceType.TWO_WAY)
     ])

--- a/worlds/oot_soh/location_access/overworld/kokiri_forest.py
+++ b/worlds/oot_soh/location_access/overworld/kokiri_forest.py
@@ -211,10 +211,8 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Connections
     connect_regions(Regions.KF_OUTSIDE_DEKU_TREE, world, [
-        (Regions.DEKU_TREE_ENTRYWAY, lambda bundle: (is_child(bundle))
-         # Todo: Add dungeons shuffle rule when entrance shuffle is implementedd
-         and (world.options.closed_forest.value == 2
-              or has_item(LocalEvents.MIDO_SWORD_AND_SHIELD, bundle))),
+        (Regions.DEKU_TREE_ENTRYWAY, lambda bundle: is_child(bundle) or (world.options.shuffle_dungeon_entrances.value > 0 and (world.options.closed_forest.value == 2 or has_item(
+            LocalEvents.MIDO_SWORD_AND_SHIELD, bundle))), SOHDungeonEntranceNames.DEKU_TREE_DUNGEON_ENTRANCE, SOHEntranceGroups.CHILD_DUNGEONS, EntranceType.TWO_WAY),
         (Regions.KOKIRI_FOREST, lambda bundle:  (is_adult(bundle) and
                                                  (can_pass_enemy(bundle, Enemies.BIG_SKULLTULA) or
                                                   has_item(Events.FOREST_TEMPLE_COMPLETED, bundle)))

--- a/worlds/oot_soh/location_access/overworld/lake_hylia.py
+++ b/worlds/oot_soh/location_access/overworld/lake_hylia.py
@@ -188,7 +188,7 @@ def set_region_rules(world: "SohWorld") -> None:
             has_item(Items.GOLDEN_SCALE, bundle))) or
           (is_adult(bundle) and
            can_use(Items.LONGSHOT, bundle) and
-           has_item(Items.GOLDEN_SCALE, bundle)))),
+           has_item(Items.GOLDEN_SCALE, bundle))), SOHDungeonEntranceNames.WATER_TEMPLE_DUNGEON_ENTRANCE, SOHEntranceGroups.ADULT_ONLY_DUNGEONS, EntranceType.TWO_WAY),
     ])
 
     # LH Fishing Island

--- a/worlds/oot_soh/location_access/overworld/sacred_forest_meadow.py
+++ b/worlds/oot_soh/location_access/overworld/sacred_forest_meadow.py
@@ -48,8 +48,8 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.SACRED_FOREST_MEADOW, world, [
         (Regions.SFM_ENTRYWAY, lambda bundle: True),
-        (Regions.FOREST_TEMPLE_ENTRYWAY,
-         lambda bundle: can_use(Items.HOOKSHOT, bundle)),
+        (Regions.FOREST_TEMPLE_ENTRYWAY, lambda bundle: can_use(Items.HOOKSHOT, bundle),
+         SOHDungeonEntranceNames.FOREST_TEMPLE_DUNGEON_ENTRANCE, SOHEntranceGroups.ADULT_ONLY_DUNGEONS, EntranceType.TWO_WAY),
         (Regions.SFM_FAIRY_GROTTO, lambda bundle: True),
         (Regions.SFM_STORMS_GROTTO, lambda bundle: can_open_storms_grotto(bundle)),
     ])

--- a/worlds/oot_soh/location_access/overworld/zoras_fountain.py
+++ b/worlds/oot_soh/location_access/overworld/zoras_fountain.py
@@ -52,8 +52,8 @@ def set_region_rules(world: "SohWorld") -> None:
             Items.SILVER_GAUNTLETS, bundle) and blast_or_smash(bundle)),
         (Regions.ZF_ROCK, lambda bundle: is_adult(
             bundle) and can_use(Items.SCARECROW, bundle)),
-        (Regions.JABU_JABUS_BELLY_ENTRYWAY,
-         lambda bundle: is_child(bundle) and (can_use(Items.BOTTLE_WITH_FISH, bundle) or world.options.jabu_jabu.value == 1)),
+        (Regions.JABU_JABUS_BELLY_ENTRYWAY, lambda bundle: is_child(bundle) and (can_use(Items.BOTTLE_WITH_FISH, bundle)
+         or world.options.jabu_jabu.value == 1), SOHDungeonEntranceNames.JABU_JABUS_DUNGEON_ENTRANCE, SOHEntranceGroups.CHILD_ONLY_DUNGEONS, EntranceType.TWO_WAY),
         (Regions.ZF_GREAT_FAIRY_FOUNTAIN, lambda bundle: has_explosives(bundle) or (can_do_trick(
             Tricks.ZF_GREAT_FAIRY_WITHOUT_EXPLOSIVES, bundle) and can_use(Items.MEGATON_HAMMER, bundle) and can_use(Items.SILVER_GAUNTLETS, bundle)))
     ])
@@ -124,7 +124,8 @@ def set_region_rules(world: "SohWorld") -> None:
         (Regions.ZORAS_FOUNTAIN, lambda bundle: has_item(Items.BRONZE_SCALE, bundle)),
         (Regions.ZF_ICEBERGS, lambda bundle: is_adult(bundle)),
         (Regions.ZF_LAKEBED, lambda bundle: can_use(Items.IRON_BOOTS, bundle)),
-        (Regions.ICE_CAVERN_ENTRYWAY, lambda bundle: True)
+        (Regions.ICE_CAVERN_ENTRYWAY, lambda bundle: True, SOHDungeonEntranceNames.ICE_CAVERN_DUNGEON_ENTRANCE,
+         SOHEntranceGroups.ADULT_ONLY_DUNGEONS, EntranceType.TWO_WAY)
     ])
 
     # Zora's Fountain Hidden Cave


### PR DESCRIPTION

Currently has Boss and Dungeons randomized. Seems pretty stable but I wouldn't be surprised if there are still some tweaks that need being made. Specifically to the Entrance Groups that tie all the stuff together need to be checked for correctness/stability.

I also had to mangle the entrances to GTG, Spirit Temple, and Ganons Castle for this to work cleanly with GER.

My testing involved generating to check for fill errors and double checking the puml file to see if what connected to what looked okay.

#198 