### PR TITLE
Added Age differentiation for locations

### DIFF
--- a/worlds/oot_soh/Locations.py
+++ b/worlds/oot_soh/Locations.py
@@ -1,10 +1,20 @@
-from .Enums import Locations
+from .Enums import Locations, Ages
 
-from BaseClasses import Location
+from BaseClasses import CollectionState, Location
 
 
 class SohLocation(Location):
     game = "Ship of Harkinian"
+
+    def can_reach(self, state: CollectionState) -> bool:
+        can_reach = False
+        # check if we can reach this as either age
+        stored_age = state._soh_age[self.player]
+        for age in [Ages.CHILD, Ages.ADULT]:
+            state._soh_age[self.player] = age
+            can_reach |= super().can_reach(state)
+        state._soh_age[self.player] = stored_age
+        return can_reach
 
 
 base_location_table: dict[str, int] = {


### PR DESCRIPTION
## What is this fixing or adding?
Fixing logic bug where age exlusive locations are available for both ages if the parent region is reachable in both cases

## How was this tested?
This can be verified using child/adult grass using the universal tracker
With door of time open and master sword shuffled, sending yourself the child sword would originally unlock all reachable grass even adult grass.
This PR fixes this and only unlocks the child grass

Some of the manual fixes for skultullas should be able to be reverted with this implemented