### PR TITLE
Update Deku Tree Torch Room Logic

### DIFF
--- a/worlds/oot_soh/location_access/dungeons/deku_tree.py
+++ b/worlds/oot_soh/location_access/dungeons/deku_tree.py
@@ -199,7 +199,7 @@ def set_region_rules(world: "SohWorld") -> None:
     # Connections
     connect_regions(Regions.DEKU_TREE_BASEMENT_TORCH_ROOM, world, [
         (Regions.DEKU_TREE_BASEMENT_WATER_ROOM_BACK, lambda bundle: has_fire_source_with_torch(
-            bundle) or can_use(Items.FAIRY_BOW, bundle),
+            bundle) or can_use(Items.FAIRY_BOW, bundle)),
         (Regions.DEKU_TREE_BASEMENT_BACK_LOBBY, lambda bundle: has_fire_source_with_torch(
             bundle) or can_use(Items.FAIRY_BOW, bundle))
     ])

--- a/worlds/oot_soh/location_access/dungeons/deku_tree.py
+++ b/worlds/oot_soh/location_access/dungeons/deku_tree.py
@@ -198,7 +198,8 @@ def set_region_rules(world: "SohWorld") -> None:
     ])
     # Connections
     connect_regions(Regions.DEKU_TREE_BASEMENT_TORCH_ROOM, world, [
-        (Regions.DEKU_TREE_BASEMENT_WATER_ROOM_BACK, lambda bundle: True),
+        (Regions.DEKU_TREE_BASEMENT_WATER_ROOM_BACK, lambda bundle: has_fire_source_with_torch(
+            bundle) or can_use(Items.FAIRY_BOW, bundle),
         (Regions.DEKU_TREE_BASEMENT_BACK_LOBBY, lambda bundle: has_fire_source_with_torch(
             bundle) or can_use(Items.FAIRY_BOW, bundle))
     ])


### PR DESCRIPTION
## What is this fixing or adding?
-Fixes the connection from Torch Room to Water Back, following Ship's logic correction. Both doors in this room are locked until the puzzle is completed.

## How was this tested?


## If this makes graphical changes, please attach screenshots.
